### PR TITLE
Change zone from static to member variable in ZoneAffinityPredicate as in some cases zone may be set when the instance is created. Change the throw clause from HttpClientResponse to general Exception for easy sub-classing

### DIFF
--- a/ribbon-core/src/main/java/com/netflix/loadbalancer/ZoneAffinityPredicate.java
+++ b/ribbon-core/src/main/java/com/netflix/loadbalancer/ZoneAffinityPredicate.java
@@ -36,7 +36,7 @@ import com.netflix.loadbalancer.Server;
  */
 public class ZoneAffinityPredicate extends AbstractServerPredicate {
 
-    private static final String zone = ConfigurationManager.getDeploymentContext().getValue(ContextKey.zone);
+    private final String zone = ConfigurationManager.getDeploymentContext().getValue(ContextKey.zone);
     
     public ZoneAffinityPredicate() {        
     }

--- a/ribbon-httpclient/src/main/java/com/netflix/niws/client/http/HttpClientResponse.java
+++ b/ribbon-httpclient/src/main/java/com/netflix/niws/client/http/HttpClientResponse.java
@@ -59,8 +59,7 @@ public class HttpClientResponse implements IResponse {
     }
        
     
-    public <T> T getEntity(Class<T> c) throws IllegalArgumentException,
-            ClientException {
+    public <T> T getEntity(Class<T> c) throws Exception {
         T t = null;
         try {
             t = this.bcr.getEntity(c);


### PR DESCRIPTION
...n some cases zone may be set when the instance is created. Change the throw clause from HttpClientResponse to general Exception for easy sub-classing.
