### PR TITLE
Make DynamicServerListLoadBalancer.updateListOfServers() public to provide alternative way to update servers at runtime instead of relying on scheduler.

### DIFF
--- a/ribbon-core/src/main/java/com/netflix/loadbalancer/DynamicServerListLoadBalancer.java
+++ b/ribbon-core/src/main/java/com/netflix/loadbalancer/DynamicServerListLoadBalancer.java
@@ -267,7 +267,7 @@ public class DynamicServerListLoadBalancer<T extends Server> extends
     }
 
     @VisibleForTesting
-    void updateListOfServers() {
+    public void updateListOfServers() {
         List<T> servers = new ArrayList<T>();
         if (serverListImpl != null) {
             servers = serverListImpl.getUpdatedListOfServers();


### PR DESCRIPTION
...de alternative way to update servers at runtime instead of relying on scheduler.
