### PR TITLE
Remove pitfall code in URI reconstruction; fix userinfo handling.

### DIFF
--- a/ribbon-core/src/test/java/com/netflix/client/LoadBalancerContextTest.java
+++ b/ribbon-core/src/test/java/com/netflix/client/LoadBalancerContextTest.java
@@ -62,6 +62,23 @@ public class LoadBalancerContextTest {
     }
     
     @Test
+    public void testPreservesUserInfo() throws ClientException {
+        // %3A == ":" -- ensure user info is not decoded
+        String uri = "http://us%3Aer:pass@localhost:8080?foo=bar";
+        HttpRequest request = HttpRequest.newBuilder().uri(uri).build();
+        HttpRequest newRequest = context.computeFinalUriWithLoadBalancer(request);
+        assertEquals(uri, newRequest.getUri().toString());
+    }
+    
+    @Test
+    public void testQueryWithoutPath() throws ClientException {
+        String uri = "?foo=bar";
+        HttpRequest request = HttpRequest.newBuilder().uri(uri).build();
+        HttpRequest newRequest = context.computeFinalUriWithLoadBalancer(request);
+        assertEquals("http://www.example.com:8080?foo=bar", newRequest.getUri().toString());
+    }
+    
+    @Test
     public void testEncodedPathAndHostChange() throws ClientException {
         String uri = "/abc%2Fxyz";
         HttpRequest request = HttpRequest.newBuilder().uri(uri).build();


### PR DESCRIPTION
- newURI was always getting overwritten under normal circumstances
  (any time there was a / or ? or similar) so isURIEncoded is not
  necessary. Use of getQuery is dangerous, but the value was being
  thrown away. This commit helps ensure it will not be used in the
  future.
- getUserInfo is replaced with getRawUserInfo to prevent premature
  decoding of separators such as ":". This should be the only behavioral
  change.

Regression test added for the latter. Characterization test added for missing path handling (behavior not changed by commit.)
