### PR TITLE
Fix visibility for HttpRequest.Builder#headers and queryParams

### DIFF
--- a/ribbon-core/src/main/java/com/netflix/client/http/HttpRequest.java
+++ b/ribbon-core/src/main/java/com/netflix/client/http/HttpRequest.java
@@ -87,12 +87,12 @@ public class HttpRequest extends ClientRequest {
             return this;
         }
         
-        Builder headers(Multimap<String, String> headers) {
+        public Builder headers(Multimap<String, String> headers) {
             request.headers = headers;
             return this;
         }
 
-        Builder queryParams(Multimap<String, String> queryParams) {
+        public Builder queryParams(Multimap<String, String> queryParams) {
             request.queryParams = queryParams;
             return this;
         }


### PR DESCRIPTION
I needed to use the 'headers' method on HttpRequest.Builder and noticed it was package private. I fixed that and queryParams as well.
