### PR TITLE
Address issue #105

### DIFF
--- a/ribbon-client-extensions/src/main/java/com/netflix/ribbonclientextensions/http/HttpMetaRequest.java
+++ b/ribbon-client-extensions/src/main/java/com/netflix/ribbonclientextensions/http/HttpMetaRequest.java
@@ -11,7 +11,6 @@ import rx.Observer;
 import rx.Observable.OnSubscribe;
 import rx.Subscriber;
 import rx.subjects.PublishSubject;
-import rx.subjects.ReplaySubject;
 import rx.subjects.Subject;
 
 import com.netflix.hystrix.HystrixExecutableInfo;
@@ -43,22 +42,22 @@ class HttpMetaRequest<T> implements RequestWithMetaData<T> {
         }        
     }
 
-    private HttpRequestBuilder<T> requestBuilder;
+    private final HttpRequest<T> request;
 
-    HttpMetaRequest(HttpRequestBuilder<T> requestBuilder ) {
-        this.requestBuilder = requestBuilder;
+    HttpMetaRequest(HttpRequest<T> request) {
+        this.request = request;
     }
 
     @Override
     public Observable<RibbonResponse<Observable<T>>> observe() {
-        RibbonHystrixObservableCommand<T> hystrixCommand = requestBuilder.createHystrixCommand();
+        RibbonHystrixObservableCommand<T> hystrixCommand = request.createHystrixCommand();
         final Observable<T> output = hystrixCommand.observe();
         return convertToRibbonResponse(output, hystrixCommand);
     }
 
     @Override
     public Observable<RibbonResponse<Observable<T>>> toObservable() {
-        RibbonHystrixObservableCommand<T> hystrixCommand = requestBuilder.createHystrixCommand();
+        RibbonHystrixObservableCommand<T> hystrixCommand = request.createHystrixCommand();
         final Observable<T> output = hystrixCommand.observe();
         return convertToRibbonResponse(output, hystrixCommand);        
     }
@@ -102,7 +101,7 @@ class HttpMetaRequest<T> implements RequestWithMetaData<T> {
 
     @Override
     public Future<RibbonResponse<T>> queue() {
-        final RibbonHystrixObservableCommand<T> hystrixCommand = requestBuilder.createHystrixCommand();
+        final RibbonHystrixObservableCommand<T> hystrixCommand = request.createHystrixCommand();
         final Future<T> f = hystrixCommand.queue();
         return new Future<RibbonResponse<T>>() {
             @Override
@@ -139,7 +138,7 @@ class HttpMetaRequest<T> implements RequestWithMetaData<T> {
 
     @Override
     public RibbonResponse<T> execute() {
-        RibbonHystrixObservableCommand<T> hystrixCommand = requestBuilder.createHystrixCommand();
+        RibbonHystrixObservableCommand<T> hystrixCommand = request.createHystrixCommand();
         T obj = hystrixCommand.execute();
         return new HttpMetaResponse<T>(obj, hystrixCommand);
     }    

--- a/ribbon-client-extensions/src/main/java/com/netflix/ribbonclientextensions/http/HttpRequest.java
+++ b/ribbon-client-extensions/src/main/java/com/netflix/ribbonclientextensions/http/HttpRequest.java
@@ -1,5 +1,14 @@
 package com.netflix.ribbonclientextensions.http;
 
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.protocol.http.client.HttpClient;
+import io.reactivex.netty.protocol.http.client.HttpClientRequest;
+import io.reactivex.netty.protocol.http.client.HttpClientResponse;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Future;
 
 import rx.Observable;
@@ -7,41 +16,90 @@ import rx.Observable.OnSubscribe;
 import rx.Subscriber;
 
 import com.netflix.hystrix.HystrixExecutableInfo;
+import com.netflix.hystrix.HystrixObservableCommand;
+import com.netflix.ribbonclientextensions.CacheProvider;
+import com.netflix.ribbonclientextensions.ResponseValidator;
 import com.netflix.ribbonclientextensions.RibbonRequest;
 import com.netflix.ribbonclientextensions.RequestWithMetaData;
 import com.netflix.ribbonclientextensions.RibbonResponse;
+import com.netflix.ribbonclientextensions.http.HttpRequestTemplate.CacheProviderWithKeyTemplate;
+import com.netflix.ribbonclientextensions.hystrix.FallbackHandler;
+import com.netflix.ribbonclientextensions.template.TemplateParser;
+import com.netflix.ribbonclientextensions.template.TemplateParsingException;
 
 class HttpRequest<T> implements RibbonRequest<T> {
+    
+    static class CacheProviderWithKey<T> {
+        CacheProvider<T> cacheProvider;
+        String key;
+        public CacheProviderWithKey(CacheProvider<T> cacheProvider, String key) {
+            super();
+            this.cacheProvider = cacheProvider;
+            this.key = key;
+        }
+        public final CacheProvider<T> getCacheProvider() {
+            return cacheProvider;
+        }
+        public final String getKey() {
+            return key;
+        }
+    }
+    
+    private final HttpClientRequest<ByteBuf> httpRequest;
+    private final String hystrixCacheKey;
+    private final List<CacheProviderWithKey<T>> cacheProviders;
+    private final Map<String, Object> requestProperties;
+    private final HttpClient<ByteBuf, ByteBuf> client;
+    private final HttpRequestTemplate<T> template;
 
-    private HttpRequestBuilder<T> requestBuilder;
+    HttpRequest(HttpRequestBuilder<T> requestBuilder) throws TemplateParsingException {
+        this.client = requestBuilder.template().getClient();
+        this.httpRequest = requestBuilder.createClientRequest();
+        this.hystrixCacheKey = requestBuilder.hystrixCacheKey();
+        this.requestProperties = new HashMap<String, Object>(requestBuilder.requestProperties());
+        this.cacheProviders = new LinkedList<CacheProviderWithKey<T>>();
+        this.template = requestBuilder.template();
+        addCacheProviders(requestBuilder.cacheProviders());
+    }
 
-    HttpRequest(HttpRequestBuilder<T> requestBuilder) {
-        this.requestBuilder = requestBuilder;
+    private void addCacheProviders(List<CacheProviderWithKeyTemplate<T>> providers) throws TemplateParsingException {
+        if (providers != null && providers.size() > 0) {
+            for (CacheProviderWithKeyTemplate<T> cacheProviderWithTemplate: providers) {
+                CacheProvider<T> provider = cacheProviderWithTemplate.getProvider();
+                String key = TemplateParser.toData(this.requestProperties, cacheProviderWithTemplate.getKeyTemplate());
+                cacheProviders.add(new CacheProviderWithKey<T>(provider, key));
+            }
+        }
+    }
+    
+    RibbonHystrixObservableCommand<T> createHystrixCommand() {
+        return new RibbonHystrixObservableCommand<T>(client, httpRequest, hystrixCacheKey, cacheProviders, requestProperties, template.fallbackHandler(), 
+                template.responseValidator(), template.getClassType(), template.hystrixProperties());
     }
     
     @Override
     public T execute() {
-        return requestBuilder.createHystrixCommand().execute();
+        return createHystrixCommand().execute();
     }
 
     @Override
     public Future<T> queue() {
-        return requestBuilder.createHystrixCommand().queue();
+        return createHystrixCommand().queue();
     }
 
     @Override
     public Observable<T> observe() {
-        return requestBuilder.createHystrixCommand().observe();
+        return createHystrixCommand().observe();
     }
 
     @Override
     public Observable<T> toObservable() {
-        return requestBuilder.createHystrixCommand().toObservable();
+        return createHystrixCommand().toObservable();
     }
 
     @Override
     public RequestWithMetaData<T> withMetadata() {
-        return new HttpMetaRequest<T>(requestBuilder);
+        return new HttpMetaRequest<T>(this);
     }
     
 

--- a/ribbon-client-extensions/src/main/java/com/netflix/ribbonclientextensions/http/HttpRequestBuilder.java
+++ b/ribbon-client-extensions/src/main/java/com/netflix/ribbonclientextensions/http/HttpRequestBuilder.java
@@ -1,43 +1,37 @@
 package com.netflix.ribbonclientextensions.http;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import io.netty.buffer.ByteBuf;
-import io.reactivex.netty.protocol.http.client.ContentSource;
 import io.reactivex.netty.protocol.http.client.HttpClient;
 import io.reactivex.netty.protocol.http.client.HttpClientRequest;
 import io.reactivex.netty.protocol.http.client.RawContentSource;
+import io.reactivex.netty.protocol.http.client.RepeatableContentHttpRequest;
 
 import com.netflix.hystrix.HystrixObservableCommand;
 import com.netflix.hystrix.exception.HystrixBadRequestException;
 import com.netflix.ribbonclientextensions.RequestTemplate.RequestBuilder;
 import com.netflix.ribbonclientextensions.RibbonRequest;
+import com.netflix.ribbonclientextensions.http.HttpRequestTemplate.CacheProviderWithKeyTemplate;
 import com.netflix.ribbonclientextensions.template.ParsedTemplate;
 import com.netflix.ribbonclientextensions.template.TemplateParser;
 import com.netflix.ribbonclientextensions.template.TemplateParsingException;
 
 public class HttpRequestBuilder<T> extends RequestBuilder<T> {
 
-    private HttpRequestTemplate<T> requestTemplate;
-    private HttpClient<ByteBuf, ByteBuf> client;
-    private HystrixObservableCommand.Setter setter;
-    private Map<String, Object> vars;
-    private ParsedTemplate parsedUriTemplate;
+    private final HttpRequestTemplate<T> requestTemplate;
+    private final Map<String, Object> vars;
+    private final ParsedTemplate parsedUriTemplate;
     private RawContentSource<?> rawContentSource;
     
-    HttpRequestBuilder(HttpClient<ByteBuf, ByteBuf> client, HttpRequestTemplate<T> requestTemplate, HystrixObservableCommand.Setter setter) {
+    HttpRequestBuilder(HttpRequestTemplate<T> requestTemplate) {
         this.requestTemplate = requestTemplate;
-        this.client = client;
-        this.setter = setter;
         this.parsedUriTemplate = requestTemplate.uriTemplate();
         vars = new ConcurrentHashMap<String, Object>();
     }
     
-    RibbonHystrixObservableCommand<T> createHystrixCommand() {
-        return new RibbonHystrixObservableCommand<T>(client, requestTemplate, this, setter);
-    }
-
     @Override
     public HttpRequestBuilder<T> withRequestProperty(
             String key, Object value) {
@@ -52,7 +46,11 @@ public class HttpRequestBuilder<T> extends RequestBuilder<T> {
 
     @Override
     public RibbonRequest<T> build() {
-        return new HttpRequest<T>(this);
+        try {
+            return new HttpRequest<T>(this);
+        } catch (TemplateParsingException e) {
+            throw new IllegalArgumentException(e);
+        }
     }
         
     HttpClientRequest<ByteBuf> createClientRequest() {
@@ -63,20 +61,31 @@ public class HttpRequestBuilder<T> extends RequestBuilder<T> {
             throw new HystrixBadRequestException("Problem parsing the URI template", e);
         }
         HttpClientRequest<ByteBuf> request =  HttpClientRequest.create(requestTemplate.method(), uri);
+        for (Map.Entry<String, String> entry: requestTemplate.getHeaders().entries()) {
+            request.withHeader(entry.getKey(), entry.getValue());
+        }
         if (rawContentSource != null) {
             request.withRawContentSource(rawContentSource);
         }
-        return request;
+        return new RepeatableContentHttpRequest<ByteBuf>(request);
     }
     
-    String cacheKey() throws TemplateParsingException {
+    String hystrixCacheKey() throws TemplateParsingException {
         if (requestTemplate.hystrixCacheKeyTemplate() == null) {
             return null;
         }
         return TemplateParser.toData(vars, requestTemplate.hystrixCacheKeyTemplate());
     }
-    
+     
     Map<String, Object> requestProperties() {
         return vars;
+    }
+    
+    List<CacheProviderWithKeyTemplate<T>> cacheProviders() {
+        return requestTemplate.cacheProviders();
+    }
+    
+    HttpRequestTemplate<T> template() {
+        return requestTemplate;
     }
 }

--- a/ribbon-client-extensions/src/main/java/com/netflix/ribbonclientextensions/http/HttpResourceGroup.java
+++ b/ribbon-client-extensions/src/main/java/com/netflix/ribbonclientextensions/http/HttpResourceGroup.java
@@ -1,21 +1,19 @@
 package com.netflix.ribbonclientextensions.http;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.reactivex.netty.protocol.http.client.HttpClient;
 
 import com.netflix.client.config.ClientConfigBuilder;
-import com.netflix.client.config.CommonClientConfigKey;
-import com.netflix.client.config.DefaultClientConfigImpl;
 import com.netflix.client.config.IClientConfig;
-import com.netflix.client.config.IClientConfigKey;
 import com.netflix.client.netty.RibbonTransport;
-import com.netflix.loadbalancer.ILoadBalancer;
 import com.netflix.ribbonclientextensions.ClientOptions;
-import com.netflix.ribbonclientextensions.RequestTemplate;
 import com.netflix.ribbonclientextensions.ResourceGroup;
 
 public class HttpResourceGroup extends ResourceGroup<HttpRequestTemplate<?>> {
     private final HttpClient<ByteBuf, ByteBuf> client;
+    private final HttpHeaders headers;
     
     public HttpResourceGroup(String groupName) {
         this(groupName, null);
@@ -24,6 +22,7 @@ public class HttpResourceGroup extends ResourceGroup<HttpRequestTemplate<?>> {
     public HttpResourceGroup(String groupName, ClientOptions options) {
         super(groupName, options);
         client = RibbonTransport.newHttpClient(getClientConfig());
+        headers = new DefaultHttpHeaders();
     }
     
     protected IClientConfig loadDefaultConfig(String groupName) {
@@ -31,6 +30,7 @@ public class HttpResourceGroup extends ResourceGroup<HttpRequestTemplate<?>> {
     }
     
     public HttpResourceGroup withCommonHeader(String name, String value) {
+        headers.add(name, value);
         return this;
     }
 
@@ -42,6 +42,10 @@ public class HttpResourceGroup extends ResourceGroup<HttpRequestTemplate<?>> {
     
     public HttpRequestTemplate<ByteBuf> newRequestTemplate(String name) {
         return newRequestTemplate(name, ByteBuf.class);
+    }
+    
+    HttpHeaders getHeaders() {
+        return headers;
     }
     
 }

--- a/ribbon-client-extensions/src/test/java/com/netflix/ribbonclientextensions/http/TemplateBuilderTest.java
+++ b/ribbon-client-extensions/src/test/java/com/netflix/ribbonclientextensions/http/TemplateBuilderTest.java
@@ -1,14 +1,42 @@
 package com.netflix.ribbonclientextensions.http;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import io.netty.buffer.ByteBuf;
 import io.reactivex.netty.protocol.http.client.HttpClientRequest;
+import io.reactivex.netty.protocol.http.client.HttpRequestHeaders;
+
+import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
 
+import rx.Observable;
+
+import com.netflix.ribbonclientextensions.CacheProvider;
 import com.netflix.ribbonclientextensions.Ribbon;
+import com.netflix.ribbonclientextensions.RibbonRequest;
 
 public class TemplateBuilderTest {
+    
+    private static class FakeCacheProvider implements CacheProvider<String> {
+        String id;
+        
+        FakeCacheProvider(String id) {
+            this.id = id;
+        }
+        
+        @Override
+        public Observable<String> get(final String key,
+                Map<String, Object> requestProperties) {
+            if (key.equals(id)) {
+                return Observable.just(id);
+
+            } else {
+                return Observable.error(new IllegalArgumentException());
+            }
+        };
+    }        
+
     @Test
     public void testVarReplacement() {
         HttpResourceGroup group = Ribbon.createHttpResourceGroup("test");
@@ -21,6 +49,44 @@ public class TemplateBuilderTest {
                 .withRequestProperty("name", "netflix")
                 .createClientRequest();
         assertEquals("/foo/3?name=netflix", request.getUri());
+    }
+    
+    @Test
+    public void testCacheKeyTemplates() {
+        HttpResourceGroup group = Ribbon.createHttpResourceGroup("test");
+        
+        HttpRequestTemplate<String> template = group.newRequestTemplate("resource1", String.class);
+        template.withUriTemplate("/foo/{id}")
+            .addCacheProvider("cache.{id}", new FakeCacheProvider("cache.3"))
+            .addCacheProvider("/cache/{id}", new FakeCacheProvider("/cache/5"));
+        RibbonRequest<String> request = template.requestBuilder().withRequestProperty("id", 3).build();
+        String result = request.execute();
+        assertEquals("cache.3", result); 
+        
+        request = template.requestBuilder().withRequestProperty("id", 5).build();
+        result = request.execute();
+        assertEquals("/cache/5", result);
+    }
+    
+    @Test
+    public void testHttpHeaders() {
+        HttpResourceGroup group = Ribbon.createHttpResourceGroup("test");
+        group.withCommonHeader("header1", "group");
+        
+        HttpRequestTemplate<String> template = group.newRequestTemplate("resource1", String.class);
+        template.withUriTemplate("/foo/bar")
+            .withHeader("header2", "template")
+            .withHeader("header1", "template");
+        
+        HttpClientRequest<ByteBuf> request = template.requestBuilder().createClientRequest();
+        HttpRequestHeaders headers = request.getHeaders();
+        List<String> header1 = headers.getAll("header1");
+        assertEquals(2, header1.size());
+        assertEquals("group", header1.get(0));
+        assertEquals("template", header1.get(1));
+        List<String> header2 = headers.getAll("header2");
+        assertEquals(1, header2.size());
+        assertEquals("template", header2.get(0));
     }
 }
 

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/LoadBalancerContext.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/LoadBalancerContext.java
@@ -461,7 +461,7 @@ public class LoadBalancerContext implements IClientConfigAware {
                 Server svc = lb.chooseServer(loadBalancerKey);
                 if (svc == null){
                     throw new ClientException(ClientException.ErrorType.GENERAL,
-                            "LoadBalancer returned null Server for :"
+                            "LoadBalancer does not have availble server for client: "
                                     + clientName);
                 }
                 host = svc.getHost();


### PR DESCRIPTION
Added handling of headers. Implemented template copy. Make sure Request can be repeatedly executed, but won’t have extra cost of parsing templates or creating HttpClientRequest each time.
