### PR TITLE
Dependency changes. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,6 @@ subprojects {
         compile 'com.google.guava:guava:14.0.1'
         compile 'com.netflix.archaius:archaius-core:0.5.12'
         compile 'com.netflix.netflix-commons:netflix-commons-util:0.1.1'
-        compile 'commons-collections:commons-collections:3.2.1'
         testCompile 'org.powermock:powermock-easymock-release-full:1.4.10'
         testCompile 'org.easymock:easymock:3.1'
         testCompile 'org.slf4j:slf4j-log4j12:1.7.2'
@@ -55,6 +54,7 @@ project(':ribbon-httpclient') {
     dependencies {
         compile project(':ribbon-core')
         compile project(':ribbon-loadbalancer')
+        compile 'commons-collections:commons-collections:3.2.1'        
         compile 'org.apache.httpcomponents:httpclient:4.2.1' 
         compile 'com.sun.jersey:jersey-client:1.11'
         compile 'com.sun.jersey:jersey-core:1.11'
@@ -71,9 +71,9 @@ project(':ribbon-transport') {
     dependencies {
         compile project(':ribbon-core')
         compile project(':ribbon-loadbalancer')
-        compile 'com.netflix.rxnetty:rx-netty:0.3.8'
-        compile 'com.netflix.rxnetty:rx-netty-contexts:0.3.8'
-        compile 'com.netflix.rxnetty:rx-netty-servo:0.3.8'
+        compile 'com.netflix.rxnetty:rx-netty:0.3.9'
+        compile 'com.netflix.rxnetty:rx-netty-contexts:0.3.9'
+        compile 'com.netflix.rxnetty:rx-netty-servo:0.3.9'
         testCompile 'com.google.mockwebserver:mockwebserver:20130706'
         testCompile project(':ribbon-test')        
     }
@@ -84,7 +84,7 @@ project(':ribbon-eureka') {
     dependencies {
         compile project(':ribbon-core')
         compile project(':ribbon-loadbalancer')
-        compile 'com.netflix.eureka:eureka-client:1.1.126'
+        compile 'com.netflix.eureka:eureka-client:1.1.136'
     }    
 }
 

--- a/ribbon/src/main/java/com/netflix/ribbon/http/HttpRequest.java
+++ b/ribbon/src/main/java/com/netflix/ribbon/http/HttpRequest.java
@@ -73,6 +73,9 @@ class HttpRequest<T> implements RibbonRequest<T> {
             this.cacheProvider = null;
         }
         this.template = requestBuilder.template();
+        if (!ByteBuf.class.isAssignableFrom(template.getClassType())) {
+            throw new IllegalArgumentException("Return type other than ByteBuf is not currently supported as serialization functionality is still work in progress");
+        }
     }
 
     RibbonHystrixObservableCommand<T> createHystrixCommand() {


### PR DESCRIPTION
Also fail fast if return type is not ByteBuf in HttpRequestTemplate.
