### PR TITLE
HttpRequest.replaceUri now includes the entity when building the new instance

### DIFF
--- a/ribbon-httpclient/src/main/java/com/netflix/client/http/HttpRequest.java
+++ b/ribbon-httpclient/src/main/java/com/netflix/client/http/HttpRequest.java
@@ -212,6 +212,8 @@ public class HttpRequest extends ClientRequest {
         .queryParams(this.queryParams)
         .setRetriable(this.isRetriable())
         .loadBalancerKey(this.getLoadBalancerKey())
-        .verb(this.getVerb()).build();        
+        .verb(this.getVerb())
+        .entity(this.entity)
+        .build();        
     }
 }


### PR DESCRIPTION
Since upgrading to 2.0-RC3 I noticed the body on requests was always empty.

HttpRequest.replaceUri was not including the entity, this may only be applicable when using a load balanced client.
