### PR TITLE
Use unsafeSubscribe() instead of subscribe() for doing recursive subscription in an Rx Operator.

### DIFF
--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/LoadBalancerExecutor.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/LoadBalancerExecutor.java
@@ -179,7 +179,7 @@ public class LoadBalancerExecutor extends LoadBalancerContext {
                             logger.error("Unexpected error", ex);
                             t1.onError(ex);
                         }
-                        retryWithSameServer(server, clientObservableProvider.run(server), retryHandler).lift(RetryNextServerOperator.this).subscribe(t1);
+                        retryWithSameServer(server, clientObservableProvider.run(server), retryHandler).lift(RetryNextServerOperator.this).unsafeSubscribe(t1);
                     } else {
                         t1.onError(finalThrowable);
                     }
@@ -273,7 +273,7 @@ public class LoadBalancerExecutor extends LoadBalancerContext {
                     }
                     
                     if (shouldRetry) {
-                        singleHostObservable.lift(RetrySameServerOperator.this).subscribe(t1);
+                        singleHostObservable.lift(RetrySameServerOperator.this).unsafeSubscribe(t1);
                     } else {
                         t1.onError(finalThrowable);
                     }


### PR DESCRIPTION
This change fixes the problem described in https://github.com/ReactiveX/RxNetty/issues/215
