### PR TITLE
Update README (@Http's uriTemplate parameter is now called uri).

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Observable<ByteBuf> result = recommendationsByUserIdTemplate.requestBuilder()
 public interface MovieService {
     @Http(
             method = HttpMethod.GET,
-            uriTemplate = "/users/{userId}/recommendations",
+            uri = "/users/{userId}/recommendations",
             )
     RibbonRequest<ByteBuf> recommendationsByUserId(@Var("userId") String userId);
 }

--- a/ribbon/README.md
+++ b/ribbon/README.md
@@ -20,7 +20,7 @@ This code snippet is taken from [ribbon-examples](../ribbon-examples) package an
 @ResourceGroup(resourceGroupClass = SampleHttpResourceGroup.class)
 public interface MovieService {
     @TemplateName("recommendations")
-    @Http(method = HttpMethod.GET, uriTemplate = "/users/{userId}/recommendations")
+    @Http(method = HttpMethod.GET, uri = "/users/{userId}/recommendations")
     @Hystrix( validator = RecommendationServiceResponseValidator.class,
               fallbackHandler = RecommendationServiceFallbackHandler.class)
     @CacheProviders(@Provider(key = "{userId}", provider = InMemoryCacheProviderFactory.class))


### PR DESCRIPTION
93ca4f911385d933c622ca24e3c7d3b177cd3e2c shortened `@Http`'s `uriTemplete` parameter to `uri`, but didn't update the READMEs.
