### PR TITLE
Allow ribbon to be compiled with java8.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,13 @@ apply plugin: 'idea'
 subprojects {
     group = "com.netflix.${githubProjectName}" // TEMPLATE: Set to organization of project
 
+    if (System.getProperty("java.version").startsWith("1.8.")) {
+        tasks.withType(Javadoc) {
+            // http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html
+            options.addStringOption('Xdoclint:none', '-quiet')
+        }
+    }
+
     dependencies {
         compile 'org.slf4j:slf4j-api:1.6.4'
         compile 'com.netflix.servo:servo-core:0.7.4'

--- a/gradle/check.gradle
+++ b/gradle/check.gradle
@@ -8,7 +8,10 @@ checkstyle {
 
 // FindBugs
 apply plugin: 'findbugs'
-findbugs {
+tasks.withType(FindBugs) { 
+    findbugs.toolVersion JavaVersion.current().isJava6() ? "2.0.1" : "3.0.0"
+    reports.html.enabled true 
+    reports.xml.enabled false
     ignoreFailures = true
 }
 


### PR DESCRIPTION
Disables doclint for the javadoc task, and uses findbugs 3.0.0 unless
compiling with java6.
