### PR TITLE
Fixed issue #182 of original project

### DIFF
--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/WeightedResponseTimeRule.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/WeightedResponseTimeRule.java
@@ -181,6 +181,7 @@ public class WeightedResponseTimeRule extends RoundRobinRule {
             // fallback to use round robin
             if (maxTotalWeight < 0.001d) {
                 server =  super.choose(getLoadBalancer(), key); 
+                return server;
             } else {
                 // generate a random weight between 0 (inclusive) to maxTotalWeight (exclusive)
                 double randomWeight = random.nextDouble() * maxTotalWeight;

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/WeightedResponseTimeRule.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/WeightedResponseTimeRule.java
@@ -180,8 +180,10 @@ public class WeightedResponseTimeRule extends RoundRobinRule {
             // No server has been hit yet and total weight is not initialized
             // fallback to use round robin
             if (maxTotalWeight < 0.001d) {
-                server =  super.choose(getLoadBalancer(), key); 
-                return server;
+                server =  super.choose(getLoadBalancer(), key);
+                if(server == null) {
+                    return server;
+                }
             } else {
                 // generate a random weight between 0 (inclusive) to maxTotalWeight (exclusive)
                 double randomWeight = random.nextDouble() * maxTotalWeight;


### PR DESCRIPTION
Infinite loop avoided by immediately returning the value of server
returned from fallback load balancer, even if it’s null which is the
case whereby no servers exist or all servers are non-reachable.