### PR TITLE
Throwing a proper RuntimeException when a property could not be loaded f...

### DIFF
--- a/ribbon-core/src/main/java/com/netflix/client/config/DefaultClientConfigImpl.java
+++ b/ribbon-core/src/main/java/com/netflix/client/config/DefaultClientConfigImpl.java
@@ -578,13 +578,14 @@ public class DefaultClientConfigImpl implements IClientConfig {
         for (Iterator<String> keys = props.getKeys(); keys.hasNext(); ){
             String key = keys.next();
             String prop = key;
-            if (prop.startsWith(getNameSpace())){
-                if (prop.length() <= getNameSpace().length() + 1) {
-                    throw new RuntimeException(String.format("Property %s is invalid", prop));
+            try {
+                if (prop.startsWith(getNameSpace())){
+                    prop = prop.substring(getNameSpace().length() + 1);
                 }
-                prop = prop.substring(getNameSpace().length() + 1);
+                setPropertyInternal(prop, getStringValue(props, key));
+            } catch (Exception ex) {
+                throw new RuntimeException(String.format("Property %s is invalid", prop));
             }
-            setPropertyInternal(prop, getStringValue(props, key));
         }
     }
     

--- a/ribbon-core/src/test/java/com/netflix/client/config/DefaultClientConfigImplTest.java
+++ b/ribbon-core/src/test/java/com/netflix/client/config/DefaultClientConfigImplTest.java
@@ -28,11 +28,17 @@ public class DefaultClientConfigImplTest {
         assertEquals(1000, config.get(CommonClientConfigKey.ConnectTimeout).intValue());
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void shouldThrowExceptionForIncorrectProperties() {
-        ConfigurationManager.getConfigInstance().setProperty("myclient.ribbon.", "bar");
+        ConfigurationManager.getConfigInstance().setProperty("myclient.ribbon", "bar");
         DefaultClientConfigImpl config = new DefaultClientConfigImpl();
-        config.loadProperties("myclient");
+        String message = "";
+        try {
+            config.loadProperties("myclient");
+        } catch (RuntimeException ex) {
+            message = ex.getMessage();
+        }
+        assertEquals("Property ribbon is invalid", message);
     }
     
     @Test


### PR DESCRIPTION
...or a client because it didn't have a property name after the namespace

The load method throws a `java.lang.StringIndexOutOfBoundsException` currently for properties like this -

myclient.ribbon.=baz
myclient.ribbon=bar

This PR throws a `java.lang.RuntimeException` with the name of the property which is invalid in the message of the exception instead of the `java.lang.StringIndexOutOfBoundsException`

We could also just log an error and load rest of the properties but this would change the current behavior where the method returns after throwing the `java.lang.StringIndexOutOfBoundsException` which also happens to be a subclass of `java.lang.RuntimeException`
