### PR TITLE
Expose ClientFactory maps

### DIFF
--- a/ribbon-loadbalancer/src/main/java/com/netflix/client/ClientFactory.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/client/ClientFactory.java
@@ -17,6 +17,7 @@
 */
 package com.netflix.client;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -249,4 +250,32 @@ public class ClientFactory {
             return config;
         }
     }
+    
+    /**
+     * Retrieves an unmodifiable map of the named clients created by the
+     * {@link ClientFactory}
+     * 
+     */
+    public static Map<String, IClient<?, ?>> getNamedClients() {
+        return Collections.unmodifiableMap(simpleClientMap);
+    }
+
+    /**
+     * Retrieves an unmodifiable map of the named load balancers created by the
+     * {@link ClientFactory}
+     * 
+     */
+    public static Map<String, ILoadBalancer> getNamedLoadBalancers() {
+        return Collections.unmodifiableMap(namedLBMap);
+    }
+
+    /**
+     * Retrieves an unmodifiable map of the named configs created by the
+     * {@link ClientFactory}
+     * 
+     */
+    public static Map<String, IClientConfig> getNamedConfigs() {
+        return Collections.unmodifiableMap(namedConfig);
+    }
+
 }

--- a/ribbon-loadbalancer/src/test/java/com/netflix/client/ClientFactoryTest.java
+++ b/ribbon-loadbalancer/src/test/java/com/netflix/client/ClientFactoryTest.java
@@ -1,0 +1,76 @@
+/*
+ *
+ * Copyright 2013 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.netflix.client.config.CommonClientConfigKey;
+import com.netflix.client.config.IClientConfig;
+import com.netflix.config.ConfigurationManager;
+import com.netflix.loadbalancer.ILoadBalancer;
+
+public class ClientFactoryTest {
+
+    private static final String CLIENT_FACTORY_MAP_TEST = "clientFactoryMapTest";
+
+    @BeforeClass
+    public static void beforeClass() {
+        ConfigurationManager.getConfigInstance().setProperty(
+                CLIENT_FACTORY_MAP_TEST + ".ribbon."
+                        + CommonClientConfigKey.ClientClassName,
+                "com.netflix.client.ClientFactoryTestClient");
+    }
+
+    @Test
+    public void testGetNamedConfigsAndNamedLoadBalancer() {
+        IClient<?, ?> namedClient = ClientFactory
+                .getNamedClient(CLIENT_FACTORY_MAP_TEST);
+
+        Map<String, IClient<?, ?>> namedClients = ClientFactory
+                .getNamedClients();
+        assertTrue(namedClients.containsKey(CLIENT_FACTORY_MAP_TEST));
+        assertEquals(namedClients.get(CLIENT_FACTORY_MAP_TEST), namedClient);
+
+        ILoadBalancer namedLoadBalancer = ClientFactory
+                .getNamedLoadBalancer(CLIENT_FACTORY_MAP_TEST);
+
+        Map<String, ILoadBalancer> namedLoadBalancers = ClientFactory
+                .getNamedLoadBalancers();
+        assertTrue(namedLoadBalancers.containsKey(CLIENT_FACTORY_MAP_TEST));
+        assertEquals(namedLoadBalancers.get(CLIENT_FACTORY_MAP_TEST),
+                namedLoadBalancer);
+    }
+
+    @Test
+    public void testGetNamedConfigs() {
+        IClientConfig namedConfig = ClientFactory
+                .getNamedConfig(CLIENT_FACTORY_MAP_TEST);
+
+        Map<String, IClientConfig> namedConfigs = ClientFactory
+                .getNamedConfigs();
+        assertTrue(namedConfigs.containsKey(CLIENT_FACTORY_MAP_TEST));
+        assertEquals(namedConfigs.get(CLIENT_FACTORY_MAP_TEST), namedConfig);
+    }
+
+}

--- a/ribbon-loadbalancer/src/test/java/com/netflix/client/ClientFactoryTestClient.java
+++ b/ribbon-loadbalancer/src/test/java/com/netflix/client/ClientFactoryTestClient.java
@@ -1,0 +1,68 @@
+package com.netflix.client;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+
+import com.netflix.client.ClientFactoryTestClient.TestIResponse;
+import com.netflix.client.config.IClientConfig;
+import com.netflix.loadbalancer.ILoadBalancer;
+
+public class ClientFactoryTestClient extends
+        AbstractLoadBalancerAwareClient<ClientRequest, TestIResponse> {
+
+    public ClientFactoryTestClient() {
+        super(null);
+    }
+
+    public ClientFactoryTestClient(ILoadBalancer lb, IClientConfig clientConfig) {
+        super(lb, clientConfig);
+    }
+
+    @Override
+    public TestIResponse execute(ClientRequest request,
+            IClientConfig requestConfig) throws Exception {
+        return null;
+    }
+
+    @Override
+    public RequestSpecificRetryHandler getRequestSpecificRetryHandler(
+            ClientRequest request, IClientConfig requestConfig) {
+        return null;
+    }
+
+    protected static class TestIResponse implements IResponse {
+
+        @Override
+        public void close() throws IOException {
+
+        }
+
+        @Override
+        public Object getPayload() throws ClientException {
+            return null;
+        }
+
+        @Override
+        public boolean hasPayload() {
+            return false;
+        }
+
+        @Override
+        public boolean isSuccess() {
+            return false;
+        }
+
+        @Override
+        public URI getRequestedURI() {
+            return null;
+        }
+
+        @Override
+        public Map<String, ?> getHeaders() {
+            return null;
+        }
+
+    }
+
+}


### PR DESCRIPTION
Would like to be able to retrieve the list of ILoadBalancers that are being managed by the ClientFactory. Made sense to expose the other maps in the same way.
