### PR TITLE
Modifying tests to use URLs that won't redirect to country-specific 

### DIFF
--- a/ribbon-httpclient/src/test/java/com/netflix/http4/NamedConnectionPoolTest.java
+++ b/ribbon-httpclient/src/test/java/com/netflix/http4/NamedConnectionPoolTest.java
@@ -18,8 +18,6 @@
 package com.netflix.http4;
 
 import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -36,6 +34,9 @@ import com.netflix.config.ConfigurationManager;
 import com.netflix.niws.client.http.RestClient;
 
 public class NamedConnectionPoolTest {
+    
+    private static final String URL = "https://www.facebook.com/";
+
     @Test
     public void testConnectionPoolCounters() throws Exception {
         // LogManager.getRootLogger().setLevel((Level)Level.DEBUG);
@@ -52,7 +53,7 @@ public class NamedConnectionPoolTest {
         System.out.println("Deleted :" + connectionPool.getDeleteCount());
         System.out.println("Released: " + connectionPool.getReleaseCount());
         for (int i = 0; i < 10; i++) {
-            HttpUriRequest request = new HttpGet("http://www.google.com/");
+            HttpUriRequest request = new HttpGet(URL);
             HttpResponse response = client.execute(request);
             EntityUtils.consume(response.getEntity());
             assertEquals(200, response.getStatusLine().getStatusCode());
@@ -85,7 +86,7 @@ public class NamedConnectionPoolTest {
         assertNotNull(httpclient);
         com.netflix.client.http.HttpResponse response = null;
         try {
-            response = client.execute(HttpRequest.newBuilder().uri("http://www.google.com/").build());
+            response = client.execute(HttpRequest.newBuilder().uri(URL).build());
         } finally {
             if (response != null) {
                 response.close();

--- a/ribbon-httpclient/src/test/java/com/netflix/niws/client/http/RestClientTest.java
+++ b/ribbon-httpclient/src/test/java/com/netflix/niws/client/http/RestClientTest.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.netflix.client.ClientFactory;
@@ -41,8 +42,8 @@ import com.netflix.loadbalancer.Server;
 public class RestClientTest {
     @Test
     public void testExecuteWithoutLB() throws Exception {
-        RestClient client = (RestClient) ClientFactory.getNamedClient("google");
-        HttpRequest request = HttpRequest.newBuilder().uri(new URI("http://www.google.com/")).build();
+        RestClient client = (RestClient) ClientFactory.getNamedClient("fb");
+        HttpRequest request = HttpRequest.newBuilder().uri(new URI("https://www.facebook.com/")).build();
         HttpResponse response = client.executeWithLoadBalancer(request);
         assertEquals(200, response.getStatus());
         response = client.execute(request);
@@ -79,21 +80,21 @@ public class RestClientTest {
 
     @Test
     public void testVipAsURI()  throws Exception {
-    	ConfigurationManager.getConfigInstance().setProperty("test1.ribbon.DeploymentContextBasedVipAddresses", "www.google.com:80");
+    	ConfigurationManager.getConfigInstance().setProperty("test1.ribbon.DeploymentContextBasedVipAddresses", "www.nytimes.com:80");
     	ConfigurationManager.getConfigInstance().setProperty("test1.ribbon.InitializeNFLoadBalancer", "false");
         RestClient client = (RestClient) ClientFactory.getNamedClient("test1");
         assertNull(client.getLoadBalancer());
         HttpRequest request = HttpRequest.newBuilder().uri(new URI("/")).build();
         HttpResponse response = client.executeWithLoadBalancer(request);
         assertEquals(200, response.getStatus());
-        assertEquals("http://www.google.com:80/", response.getRequestedURI().toString());
+        assertEquals("http://www.nytimes.com:80/", response.getRequestedURI().toString());
     }
 
     @Test
     public void testSecureClient()  throws Exception {
     	ConfigurationManager.getConfigInstance().setProperty("test2.ribbon.IsSecure", "true");
     	RestClient client = (RestClient) ClientFactory.getNamedClient("test2");
-        HttpRequest request = HttpRequest.newBuilder().uri(new URI("https://www.google.com/")).build();
+        HttpRequest request = HttpRequest.newBuilder().uri(new URI("https://www.facebook.com/")).build();
         HttpResponse response = client.executeWithLoadBalancer(request);
         assertEquals(200, response.getStatus());
     }
@@ -103,13 +104,13 @@ public class RestClientTest {
         ConfigurationManager.getConfigInstance().setProperty("test3.ribbon.IsSecure", "true");
         RestClient client = (RestClient) ClientFactory.getNamedClient("test3");
         BaseLoadBalancer lb = new BaseLoadBalancer();
-        Server[] servers = new Server[]{new Server("www.google.com", 443)};
+        Server[] servers = new Server[]{new Server("www.facebook.com", 443)};
         lb.addServers(Arrays.asList(servers));
         client.setLoadBalancer(lb);
         HttpRequest request = HttpRequest.newBuilder().uri(new URI("/")).build();
         HttpResponse response = client.executeWithLoadBalancer(request);
         assertEquals(200, response.getStatus());
-        assertEquals("https://www.google.com:443/", response.getRequestedURI().toString());
+        assertEquals("https://www.facebook.com:443/", response.getRequestedURI().toString());
 
     }
 


### PR DESCRIPTION
Modifying tests to use URLs that won't redirect to country-specific when executed outside the US. Otherwise, these tests will fail systematically, because they're expecting HTTP 200 and not 302. I mostly used Facebook.com instead of Google. In a specific case, where the aim was to use port 80, I used nytimes.com, because FB, Google and LinkedIn will all redirect to their HTTPS URLs if targeted on port 80.