### PR TITLE
Removing unnecessary usage of intrinsic lock

### DIFF
--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/BaseLoadBalancer.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/BaseLoadBalancer.java
@@ -68,11 +68,10 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
     protected IPing ping = null;
 
     @Monitor(name = PREFIX + "AllServerList", type = DataSourceType.INFORMATIONAL)
-    protected volatile List<Server> allServerList = Collections
-            .synchronizedList(new ArrayList<Server>());
+    protected volatile List<Server> allServerList = new ArrayList<Server>();
+    
     @Monitor(name = PREFIX + "UpServerList", type = DataSourceType.INFORMATIONAL)
-    protected volatile List<Server> upServerList = Collections
-            .synchronizedList(new ArrayList<Server>());
+    protected volatile List<Server> upServerList = new ArrayList<Server>();
 
     protected ReadWriteLock allServerLock = new ReentrantReadWriteLock();
     protected ReadWriteLock upServerLock = new ReentrantReadWriteLock();
@@ -421,7 +420,7 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
         if ((newServers != null) && (newServers.length > 0)) {
 
             try {
-                ArrayList<Server> newList = new ArrayList<Server>();
+                List<Server> newList = new ArrayList<Server>();
                 newList.addAll(allServerList);
 
                 for (Object server : newServers) {
@@ -450,10 +449,10 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
         if (logger.isDebugEnabled()) {
             logger.debug("LoadBalancer:  clearing server list (SET op)");
         }
-        ArrayList<Server> newServers = new ArrayList<Server>();
+        List<Server> newServers = new ArrayList<Server>();
         writeLock.lock();
         try {
-            ArrayList<Server> allServers = new ArrayList<Server>();
+            List<Server> allServers = new ArrayList<Server>();
             for (Object server : lsrv) {
                 if (server == null) {
                     continue;
@@ -525,7 +524,7 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
 
             try {
                 String[] serverArr = srvString.split(",");
-                ArrayList<Server> newList = new ArrayList<Server>();
+                List<Server> newList = new ArrayList<Server>();
 
                 for (String serverString : serverArr) {
                     if (serverString != null) {
@@ -572,9 +571,9 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
         case STATUS_UP:
             return upServerList;
         case STATUS_NOT_UP:
-            ArrayList<Server> notAvailableServers = new ArrayList<Server>(
+            List<Server> notAvailableServers = new ArrayList<Server>(
                     allServerList);
-            ArrayList<Server> upServers = new ArrayList<Server>(upServerList);
+            List<Server> upServers = new ArrayList<Server>(upServerList);
             notAvailableServers.removeAll(upServers);
             return notAvailableServers;
         }
@@ -672,7 +671,7 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
                     }
                 }
 
-                ArrayList<Server> newUpList = new ArrayList<Server>();
+                List<Server> newUpList = new ArrayList<Server>();
 
                 for (int i = 0; i < numCandidates; i++) {
                     boolean isAlive = results[i];


### PR DESCRIPTION
``Collection.synchronizedList`` is called while creating both ``allServerList``and ``upServerList``, but these lists are guarded by explicit ``ReadWriteLock``s. While this may be considered not harmful, it leads to extra lock contention, i.e. reader threads will have to wait to acquire the intrinsic lock (that makes no distinction between read and write operations), while they could have move forward acquiring the explicit read lock. On top of that, the use of ``synchronizedList`` **and** explicit locks complicates the task of understanding how concurrency is handled in the ``BaseLoadBalancer``. 

The aforementioned contention issue is probably not that noticeable because, as soon as any of the lists is updated, it's replaced with a non-synchronized list, since a ``new ArrayList<Server>()`` is performed. So, it reinforces the idea that the use of ``Collection.synchronizedList``is unnecessary.