### PR TITLE
Removed overriding of BaseLoadBalancer#setPing from DynamicServerListLoadBalancer

### DIFF
--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/DynamicServerListLoadBalancer.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/DynamicServerListLoadBalancer.java
@@ -211,11 +211,6 @@ public class DynamicServerListLoadBalancer<T extends Server> extends
         this.serverListImpl = niwsServerList;
     }
 
-    @Override
-    public void setPing(IPing ping) {
-        this.ping = ping;
-    }
-
     public ServerListFilter<T> getFilter() {
         return filter;
     }


### PR DESCRIPTION
Motivation:

`DynamicServerListLoadBalancer` implementation of `setPing` does not call `super.setPing`
which causes the load balancer to completely ignore the ping interval configuration.

Modifications:

Removed unnecessary overriding of `setPing`

Result:

Ping interval configuration works as expected. Fixes #200 