### PR TITLE
Fixed PrimeConnectionsClassName to have String type

### DIFF
--- a/ribbon-core/src/main/java/com/netflix/client/config/CommonClientConfigKey.java
+++ b/ribbon-core/src/main/java/com/netflix/client/config/CommonClientConfigKey.java
@@ -56,7 +56,7 @@ public abstract class CommonClientConfigKey<T> implements IClientConfigKey<T> {
     
     public static final IClientConfigKey<Boolean> EnablePrimeConnections = new CommonClientConfigKey<Boolean>("EnablePrimeConnections"){};
     
-    public static final IClientConfigKey<Boolean> PrimeConnectionsClassName = new CommonClientConfigKey<Boolean>("PrimeConnectionsClassName"){};
+    public static final IClientConfigKey<String> PrimeConnectionsClassName = new CommonClientConfigKey<String>("PrimeConnectionsClassName"){};
     
     public static final IClientConfigKey<Integer> MaxRetriesPerServerPrimeConnection = new CommonClientConfigKey<Integer>("MaxRetriesPerServerPrimeConnection"){};
     

--- a/ribbon-loadbalancer/src/main/java/com/netflix/client/PrimeConnections.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/client/PrimeConnections.java
@@ -144,8 +144,8 @@ public class PrimeConnections {
         }
         primeConnectionsURI = String.valueOf(niwsClientConfig.getProperty(CommonClientConfigKey.PrimeConnectionsURI, primeConnectionsURI));
         float primeRatio = Float.parseFloat(String.valueOf(niwsClientConfig.getProperty(CommonClientConfigKey.MinPrimeConnectionsRatio)));
-        className = (String) niwsClientConfig.getProperty(CommonClientConfigKey.PrimeConnectionsClassName, 
-        		DefaultClientConfigImpl.DEFAULT_PRIME_CONNECTIONS_CLASS);
+        className = niwsClientConfig.getPropertyAsString(CommonClientConfigKey.PrimeConnectionsClassName,
+                DefaultClientConfigImpl.DEFAULT_PRIME_CONNECTIONS_CLASS);
         try {
             connector = (IPrimeConnection) Class.forName(className).newInstance();
             connector.initWithNiwsConfig(niwsClientConfig);


### PR DESCRIPTION
Motivation:

`CommonClientConfigKey.PrimeConnectionsClassName` is typed as `IClientConfigKey<Boolean>`
which is incorrect since it class names are strings

Modifications:

Make `PrimeConnectionsClassName` a constant of type `IClientConfigKey<String>`

Result:

Fixes #207