### PR TITLE
Fixed ReceiveBuffferSize typo

### DIFF
--- a/ribbon-core/src/main/java/com/netflix/client/config/CommonClientConfigKey.java
+++ b/ribbon-core/src/main/java/com/netflix/client/config/CommonClientConfigKey.java
@@ -52,7 +52,7 @@ public abstract class CommonClientConfigKey<T> implements IClientConfigKey<T> {
     
     public static final IClientConfigKey<Boolean> RequestSpecificRetryOn = new CommonClientConfigKey<Boolean>("RequestSpecificRetryOn"){};
     
-    public static final IClientConfigKey<Integer> ReceiveBuffferSize = new CommonClientConfigKey<Integer>("ReceiveBuffferSize"){};
+    public static final IClientConfigKey<Integer> ReceiveBufferSize = new CommonClientConfigKey<Integer>("ReceiveBufferSize"){};
     
     public static final IClientConfigKey<Boolean> EnablePrimeConnections = new CommonClientConfigKey<Boolean>("EnablePrimeConnections"){};
     

--- a/ribbon-httpclient/src/main/java/com/netflix/niws/client/http/RestClient.java
+++ b/ribbon-httpclient/src/main/java/com/netflix/niws/client/http/RestClient.java
@@ -280,16 +280,16 @@ public class RestClient extends AbstractLoadBalancerAwareClient<HttpRequest, Htt
         // send/receive - so let's take the bigger of the two values and use
         // it as buffer size
         int bufferSize = Integer.MIN_VALUE;
-        if (ncc.getProperty(CommonClientConfigKey.ReceiveBuffferSize) != null) {
+        if (ncc.getProperty(CommonClientConfigKey.ReceiveBufferSize) != null) {
             try {
                 bufferSize = Integer
                 .parseInt(""
                         + ncc
-                        .getProperty(CommonClientConfigKey.ReceiveBuffferSize));
+                        .getProperty(CommonClientConfigKey.ReceiveBufferSize));
             } catch (Exception e) {
                 throw new IllegalArgumentException(
                         "Invalid value for property:"
-                        + CommonClientConfigKey.ReceiveBuffferSize,
+                        + CommonClientConfigKey.ReceiveBufferSize,
                         e);
             }
             if (ncc.getProperty(CommonClientConfigKey.SendBufferSize) != null) {


### PR DESCRIPTION
Renamed `ReceiveBuffferSize` to `ReceiveBufferSize`

This is not backwards compatible if there's people using this configuration already.