### PR TITLE
Added listener notification on server status changes to BaseLoadBalancer

### DIFF
--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ServerStatusChangeListener.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ServerStatusChangeListener.java
@@ -1,0 +1,14 @@
+package com.netflix.loadbalancer;
+
+import java.util.Collection;
+
+public interface ServerStatusChangeListener {
+
+    /**
+     * Invoked by {@link BaseLoadBalancer} when server status has changed (e.g. when marked as down or found dead by ping).
+     *
+     * @param servers the servers that had their status changed, never {@code null}
+     */
+    public void serverStatusChanged(Collection<Server> servers);
+
+}

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ServerStatusChangeListener.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ServerStatusChangeListener.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.loadbalancer;
 
 import java.util.Collection;

--- a/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/ServerStatusChangeListenerTest.java
+++ b/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/ServerStatusChangeListenerTest.java
@@ -1,0 +1,70 @@
+package com.netflix.loadbalancer;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.AllOf.allOf;
+import static org.junit.Assert.assertThat;
+
+public class ServerStatusChangeListenerTest {
+
+    private final Server server1 = new Server("www.google.com:80");
+    private final Server server2 = new Server("www.netflix.com:80");
+
+    private BaseLoadBalancer lb;
+    private AtomicReference<List<Server>> serversReceivedByListener;
+
+    @Before
+    public void setupLoadbalancerAndListener() {
+        lb = new BaseLoadBalancer();
+        lb.setServersList(asList(server1, server2));
+        serversReceivedByListener = new AtomicReference<List<Server>>();
+        lb.addServerStatusChangeListener(new ServerStatusChangeListener() {
+            @Override
+            public void serverStatusChanged(final Collection<Server> servers) {
+                serversReceivedByListener.set(new ArrayList<Server>(servers));
+            }
+        });
+    }
+
+    @Test
+    public void markServerDownByIdShouldBeReceivedByListener() {
+        lb.markServerDown(server1.getId());
+        assertThat(serversReceivedByListener.get(), is(singletonList(server1)));
+        lb.markServerDown(server2.getId());
+        assertThat(serversReceivedByListener.get(), is(singletonList(server2)));
+    }
+
+    @Test
+    public void markServerDownByObjectShouldBeReceivedByListener() {
+        lb.markServerDown(server1);
+        assertThat(serversReceivedByListener.get(), is(singletonList(server1)));
+        lb.markServerDown(server2);
+        assertThat(serversReceivedByListener.get(), is(singletonList(server2)));
+    }
+
+
+    @Test
+    public void changeServerStatusByPingShouldBeReceivedByListener() {
+        final PingConstant ping = new PingConstant();
+        lb.setPing(ping);
+
+        ping.setConstant(false);
+        lb.forceQuickPing();
+        assertThat(serversReceivedByListener.get(), allOf(hasItem(server1), hasItem(server2)));
+
+        ping.setConstant(true);
+        lb.forceQuickPing();
+        assertThat(serversReceivedByListener.get(), allOf(hasItem(server1), hasItem(server2)));
+    }
+
+}

--- a/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/ServerStatusChangeListenerTest.java
+++ b/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/ServerStatusChangeListenerTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.loadbalancer;
 
 import org.junit.Before;


### PR DESCRIPTION
Fix for issue #218: Taking the cue from the existing ServerListChangeListener I have added a ServerStatusChangeListener that may be registered with BaseLoadBalancer to receive notifications on server status changes (server down/up).

We have had this code in production for some time now and would like to see it included in Ribbon.