### PR TITLE
Remove fixed inital delay for dynamic server list reload

### DIFF
--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/DynamicServerListLoadBalancer.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/DynamicServerListLoadBalancer.java
@@ -64,7 +64,6 @@ public class DynamicServerListLoadBalancer<T extends Server> extends
     protected AtomicBoolean serverListUpdateInProgress = new AtomicBoolean(
             false);
 
-    private static long LISTOFSERVERS_CACHE_UPDATE_DELAY = 1000; // msecs;
     private static int LISTOFSERVERS_CACHE_REPEAT_INTERVAL = 30 * 1000; // msecs;
                                                                          // //
                                                                          // every
@@ -250,7 +249,7 @@ public class DynamicServerListLoadBalancer<T extends Server> extends
     private void keepServerListUpdated() {
         scheduledFuture = _serverListRefreshExecutor.scheduleAtFixedRate(
                 new ServerListRefreshExecutorThread(),
-                LISTOFSERVERS_CACHE_UPDATE_DELAY, refeshIntervalMills,
+                refeshIntervalMills, refeshIntervalMills,
                 TimeUnit.MILLISECONDS);
     }
 

--- a/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/DynamicServerListLoadBalancerTest.java
+++ b/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/DynamicServerListLoadBalancerTest.java
@@ -65,21 +65,22 @@ public class DynamicServerListLoadBalancerTest {
 
     @Test
     public void testDynamicServerListLoadBalancer() throws Exception {
-        DefaultClientConfigImpl config = DefaultClientConfigImpl.getClientConfigWithDefaultValues();
+        final int refreshIntervalMillis = 50;
+        final DefaultClientConfigImpl config = DefaultClientConfigImpl.getClientConfigWithDefaultValues();
         config.setProperty(CommonClientConfigKey.NIWSServerListClassName, MyServerList.class.getName());
         config.setProperty(CommonClientConfigKey.NFLoadBalancerClassName, DynamicServerListLoadBalancer.class.getName());
-        config.setProperty(CommonClientConfigKey.ServerListRefreshInterval, "50");
+        config.setProperty(CommonClientConfigKey.ServerListRefreshInterval, refreshIntervalMillis);
         DynamicServerListLoadBalancer<Server> lb = new DynamicServerListLoadBalancer<Server>(config);
         try {
-            assertTrue(MyServerList.latch.await(2, TimeUnit.SECONDS));
+            assertTrue(MyServerList.latch.await(refreshIntervalMillis * (5 + 1), TimeUnit.MILLISECONDS));
         } catch (InterruptedException e) { // NOPMD
         }
         assertEquals(lb.getServerList(false), MyServerList.list);
         lb.stopServerListRefreshing();
-        Thread.sleep(1000);
+        Thread.sleep(refreshIntervalMillis * 2);
         int count = MyServerList.counter.get();
         assertTrue(count >= 5);
-        Thread.sleep(1000);
+        Thread.sleep(refreshIntervalMillis * 2);
         assertEquals(count, MyServerList.counter.get());
         
     }


### PR DESCRIPTION
Removes the hard-coded 1 second initial delay for reloading the dynamic server list in DynamicServerListLoadBalancer (fixes #224).