### PR TITLE
Change base class in CompositeEurekaEnabledNIWSServerList to AbstractServerList

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ servo_version=0.9.2
 hystrix_version=1.4.3
 guava_version=14.0.1
 archaius_version=0.6.6
-eureka_version=1.1.152
+eureka_version=1.1.153
 eureka2_version=2.0.0-rc.2
 
 junit_version=4.12

--- a/ribbon-eureka/src/main/java/com/netflix/niws/loadbalancer/CompositeEurekaEnabledNIWSServerList.java
+++ b/ribbon-eureka/src/main/java/com/netflix/niws/loadbalancer/CompositeEurekaEnabledNIWSServerList.java
@@ -3,17 +3,16 @@ package com.netflix.niws.loadbalancer;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import com.netflix.client.IClientConfigAware;
 import com.netflix.client.config.IClientConfig;
-import com.netflix.loadbalancer.ServerList;
+import com.netflix.loadbalancer.AbstractServerList;
 
 /**
  * @author Tomasz Bak
  */
-public class CompositeEurekaEnabledNIWSServerList implements ServerList<DiscoveryEnabledServer>, IClientConfigAware {
+public class CompositeEurekaEnabledNIWSServerList extends AbstractServerList<DiscoveryEnabledServer> {
 
     private DiscoveryEnabledNIWSServerList eureka1ServerList;
-    private AtomicReference<Eureka2EnabledNIWSServerList> eureka2ServerListRef = new AtomicReference<>();
+    private final AtomicReference<Eureka2EnabledNIWSServerList> eureka2ServerListRef = new AtomicReference<>();
     private IClientConfig clientConfig;
 
     @Override


### PR DESCRIPTION
Change base class in CompositeEurekaEnabledNIWSServerList to AbstractServerList
to inherit zone filtering capabilities.