### PR TITLE
Close HttpResponse after usage.

### DIFF
--- a/ribbon-httpclient/src/test/java/com/netflix/client/samples/SampleApp.java
+++ b/ribbon-httpclient/src/test/java/com/netflix/client/samples/SampleApp.java
@@ -40,6 +40,7 @@ public class SampleApp {
         for (int i = 0; i < 20; i++)  {
         	HttpResponse response = client.executeWithLoadBalancer(request); // 4
         	System.out.println("Status code for " + response.getRequestedURI() + "  :" + response.getStatus());
+                response.close();
         }
         ZoneAwareLoadBalancer lb = (ZoneAwareLoadBalancer) client.getLoadBalancer();
         System.out.println(lb.getLoadBalancerStats());
@@ -50,8 +51,8 @@ public class SampleApp {
         for (int i = 0; i < 20; i++)  {
         	HttpResponse response = client.executeWithLoadBalancer(request);
         	System.out.println("Status code for " + response.getRequestedURI() + "  : " + response.getStatus());
+                response.close();
         }
         System.out.println(lb.getLoadBalancerStats()); // 7
 	}
-
 }


### PR DESCRIPTION
Although this is a trivial example, any usage of this pattern of code with a larger number of requests will rapidly exhaust the connection pool.