### PR TITLE
Enable building Ribbon for Java 1.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ subprojects {
     apply plugin: 'nebula.netflixoss'
     apply plugin: 'java'
 
-    sourceCompatibility = 1.7
-    targetCompatibility = 1.7
+    sourceCompatibility = 1.6
+    targetCompatibility = 1.6
 
     group = "com.netflix.${githubProjectName}" // TEMPLATE: Set to organization of project
 

--- a/ribbon-eureka/src/main/java/com/netflix/niws/loadbalancer/CompositeEurekaEnabledNIWSServerList.java
+++ b/ribbon-eureka/src/main/java/com/netflix/niws/loadbalancer/CompositeEurekaEnabledNIWSServerList.java
@@ -12,7 +12,8 @@ import com.netflix.loadbalancer.AbstractServerList;
 public class CompositeEurekaEnabledNIWSServerList extends AbstractServerList<DiscoveryEnabledServer> {
 
     private DiscoveryEnabledNIWSServerList eureka1ServerList;
-    private final AtomicReference<Eureka2EnabledNIWSServerList> eureka2ServerListRef = new AtomicReference<>();
+    private final AtomicReference<Eureka2EnabledNIWSServerList> eureka2ServerListRef =
+            new AtomicReference<Eureka2EnabledNIWSServerList>();
     private IClientConfig clientConfig;
 
     @Override

--- a/ribbon-eureka/src/main/java/com/netflix/niws/loadbalancer/Eureka2Clients.java
+++ b/ribbon-eureka/src/main/java/com/netflix/niws/loadbalancer/Eureka2Clients.java
@@ -14,7 +14,8 @@ import com.netflix.eureka2.client.EurekaInterestClient;
  */
 public final class Eureka2Clients {
 
-    private static final AtomicReference<EurekaInterestClient> interestClient = new AtomicReference<>();
+    private static final AtomicReference<EurekaInterestClient> interestClient =
+            new AtomicReference<EurekaInterestClient>();
     private static final AtomicBoolean useEureka2 = new AtomicBoolean();
 
     private Eureka2Clients() {

--- a/ribbon-eureka/src/main/java/com/netflix/niws/loadbalancer/Eureka2EnabledNIWSServerList.java
+++ b/ribbon-eureka/src/main/java/com/netflix/niws/loadbalancer/Eureka2EnabledNIWSServerList.java
@@ -158,7 +158,7 @@ public class Eureka2EnabledNIWSServerList extends AbstractServerList<DiscoveryEn
     }
 
     private List<DiscoveryEnabledServer> toServerList(List<InstanceInfo> listOfinstanceInfo) {
-        List<DiscoveryEnabledServer> serverList = new ArrayList<>(listOfinstanceInfo.size());
+        List<DiscoveryEnabledServer> serverList = new ArrayList<DiscoveryEnabledServer>(listOfinstanceInfo.size());
         for (InstanceInfo ii : listOfinstanceInfo) {
             if (ii.getStatus() == InstanceStatus.UP) {
                 if (shouldUseOverridePort) {


### PR DESCRIPTION
Ribbon is currently targeted to 1.7 even though it's dependencies are built for 1.6.  It would be nice if Ribbon supported 1.6.

We have a few legacy applications which use Ribbon and would benefit from the ReadTimeout fix introduced in 2.1.1.  However these applications run on a 1.6 JVM and we don't have any immediate plans to upgrade the Java version.

I'm sure there may be other applications using 1.6 which would benefit from using Ribbon as well, but can't since the target is 1.7.