### PR TITLE
Do not include request entity on DELETE

### DIFF
--- a/ribbon-httpclient/src/main/java/com/netflix/niws/client/http/RestClient.java
+++ b/ribbon-httpclient/src/main/java/com/netflix/niws/client/http/RestClient.java
@@ -624,7 +624,7 @@ public class RestClient extends AbstractLoadBalancerAwareClient<HttpRequest, Htt
             jerseyResponse = b.put(ClientResponse.class, entity);
             break;
         case DELETE:
-            jerseyResponse = b.delete(ClientResponse.class, entity);
+            jerseyResponse = b.delete(ClientResponse.class);
             break;
         case HEAD:
             jerseyResponse = b.head();

--- a/ribbon-httpclient/src/test/java/com/netflix/niws/client/http/RestClientTest.java
+++ b/ribbon-httpclient/src/test/java/com/netflix/niws/client/http/RestClientTest.java
@@ -125,6 +125,18 @@ public class RestClientTest {
         
     }
 
+    @Test
+    public void testDelete() throws Exception {
+        RestClient client = (RestClient) ClientFactory.getNamedClient("google");
+        HttpRequest request = HttpRequest.newBuilder().uri(server.getServerURI()).verb(HttpRequest.Verb.DELETE).build();
+        HttpResponse response = client.execute(request);
+        assertStatusIsOk(response.getStatus());
+        
+        request = HttpRequest.newBuilder().uri(server.getServerURI()).verb(HttpRequest.Verb.DELETE).entity("").build();
+        response = client.execute(request);
+        assertStatusIsOk(response.getStatus());
+    }
+
     private void assertStatusIsOk(int status) {
         assertTrue(status == 200 || status == 302);
     }


### PR DESCRIPTION
The RestClient does not handle DELETE actions by incorrectly supplying an entity when it is explicitly forbidden.

```
Caused by: com.sun.jersey.api.client.ClientHandlerException: Adding entity to http method DELETE is not supported.
	at com.sun.jersey.client.apache4.ApacheHttpClient4Handler.getUriHttpRequest(ApacheHttpClient4Handler.java:238)
	at com.sun.jersey.client.apache4.ApacheHttpClient4Handler.handle(ApacheHttpClient4Handler.java:157)
	at com.sun.jersey.api.client.Client.handle(Client.java:652)
	at com.sun.jersey.api.client.WebResource.handle(WebResource.java:682)
	at com.sun.jersey.api.client.WebResource.access$200(WebResource.java:74)
	at com.sun.jersey.api.client.WebResource$Builder.delete(WebResource.java:601)
	at com.netflix.niws.client.http.RestClient.execute(RestClient.java:627)
	at com.netflix.niws.client.http.RestClient.execute(RestClient.java:527)
	at com.netflix.niws.client.http.RestClient.execute(RestClient.java:92)
	at com.netflix.client.AbstractLoadBalancerAwareClient$1.call(AbstractLoadBalancerAwareClient.java:109)
	at com.netflix.loadbalancer.reactive.LoadBalancerCommand$3$1.call(LoadBalancerCommand.java:303)
	at com.netflix.loadbalancer.reactive.LoadBalancerCommand$3$1.call(LoadBalancerCommand.java:287)
```