### PR TITLE
Add atomic cyclic counting to RoundRobinRule.

### DIFF
--- a/ribbon-eureka/src/test/java/com/netflix/niws/loadbalancer/LBBuilderTest.java
+++ b/ribbon-eureka/src/test/java/com/netflix/niws/loadbalancer/LBBuilderTest.java
@@ -101,7 +101,7 @@ public class LBBuilderTest {
                 .withServerListFilter(filter)
                 .buildDynamicServerListLoadBalancer();
         assertNotNull(lb);
-        assertEquals(Lists.newArrayList(expected), lb.getServerList(false));
+        assertEquals(Lists.newArrayList(expected), lb.getAllServers());
         assertSame(filter, lb.getFilter());
         assertSame(list, lb.getServerListImpl());
         Server server = lb.chooseServer();
@@ -126,7 +126,7 @@ public class LBBuilderTest {
         assertTrue(dynamicLB.getFilter() instanceof ZoneAffinityServerListFilter);
         assertTrue(dynamicLB.getRule() instanceof RoundRobinRule);
         assertTrue(dynamicLB.getPing() instanceof DummyPing);
-        assertEquals(Lists.newArrayList(expected), lb.getServerList(false));
+        assertEquals(Lists.newArrayList(expected), lb.getAllServers());
     }
 
     @Test
@@ -141,7 +141,7 @@ public class LBBuilderTest {
         BaseLoadBalancer lb = LoadBalancerBuilder.newBuilder()
                 .withRule(rule)
                 .buildFixedServerListLoadBalancer(list);
-        assertEquals(list, lb.getServerList(false));
+        assertEquals(list, lb.getAllServers());
         assertSame(rule, lb.getRule());
     }
 }

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/AvailabilityFilteringRule.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/AvailabilityFilteringRule.java
@@ -65,7 +65,7 @@ public class AvailabilityFilteringRule extends PredicateBasedRule {
     @Monitor(name="AvailableServersCount", type = DataSourceType.GAUGE)
     public int getAvailableServersCount() {
     	ILoadBalancer lb = getLoadBalancer();
-    	List<Server> servers = lb.getServerList(false);
+    	List<Server> servers = lb.getAllServers();
     	if (servers == null) {
     		return 0;
     	}

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/BaseLoadBalancer.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/BaseLoadBalancer.java
@@ -17,22 +17,6 @@
  */
 package com.netflix.loadbalancer;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.collect.ImmutableList;
 import com.netflix.client.ClientFactory;
 import com.netflix.client.IClientConfigAware;
@@ -45,6 +29,15 @@ import com.netflix.servo.annotations.Monitor;
 import com.netflix.servo.monitor.Counter;
 import com.netflix.servo.monitor.Monitors;
 import com.netflix.util.concurrent.ShutdownEnabledTimer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static java.util.Collections.singleton;
 
@@ -573,8 +566,17 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
 
     @Override
     public List<Server> getServerList(boolean availableOnly) {
-        return (availableOnly ? Collections.unmodifiableList(upServerList) : 
-        	Collections.unmodifiableList(allServerList));
+        return (availableOnly ? getReachableServers() : getAllServers());
+    }
+
+    @Override
+    public List<Server> getReachableServers() {
+        return Collections.unmodifiableList(upServerList);
+    }
+
+    @Override
+    public List<Server> getAllServers() {
+        return Collections.unmodifiableList(allServerList);
     }
 
     @Override
@@ -867,7 +869,7 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
         // register the rule as it contains metric for available servers count
         Monitors.registerObject("Rule_" + name, this.getRule());
         if (enablePrimingConnections && primeConnections != null) {
-            primeConnections.primeConnections(getServerList(true));
+            primeConnections.primeConnections(getReachableServers());
         }
     }
 

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/BaseLoadBalancer.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/BaseLoadBalancer.java
@@ -234,7 +234,7 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
         }
     }
 
-    private void setupPingTask() {
+    void setupPingTask() {
         if (canSkipPing()) {
             return;
         }
@@ -630,13 +630,11 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
     class Pinger {
 
         public void runPinger() {
-
             if (pingInProgress.get()) {
                 return; // Ping in progress - nothing to do
             } else {
                 pingInProgress.set(true);
             }
-
             // we are "in" - we get to Ping
 
             Object[] allServers = null;
@@ -710,7 +708,6 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
                         newUpList.add(svr);
                     }
                 }
-                // System.out.println(count + " servers alive");
                 upLock = upServerLock.writeLock();
                 upLock.lock();
                 upServerList = newUpList;

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/BestAvailableRule.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/BestAvailableRule.java
@@ -41,7 +41,7 @@ public class BestAvailableRule extends ClientConfigEnabledRoundRobinRule {
         if (loadBalancerStats == null) {
             return super.choose(key);
         }
-        List<Server> serverList = getLoadBalancer().getServerList(false);
+        List<Server> serverList = getLoadBalancer().getAllServers();
         int minimalConcurrentConnections = Integer.MAX_VALUE;
         long currentTime = System.currentTimeMillis();
         Server chosen = null;

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/DynamicServerListLoadBalancer.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/DynamicServerListLoadBalancer.java
@@ -167,7 +167,7 @@ public class DynamicServerListLoadBalancer<T extends Server> extends
         updateListOfServers();
         if (primeConnection && this.getPrimeConnections() != null) {
             this.getPrimeConnections()
-                    .primeConnections(getServerList(true));
+                    .primeConnections(getReachableServers());
         }
         this.setEnablePrimingConnections(primeConnection);
         LOGGER.info("DynamicServerListLoadBalancer for client {} initialized: {}", clientConfig.getClientName(), this.toString());

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ILoadBalancer.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ILoadBalancer.java
@@ -59,9 +59,24 @@ public interface ILoadBalancer {
 	public void markServerDown(Server server);
 	
 	/**
+	 * @deprecated 2016-01-20 This method is deprecated in favor of the
+	 * cleaner {@link #getReachableServers} (equivalent to availableOnly=true)
+	 * and {@link #getAllServers} API (equivalent to availableOnly=false).
+	 *
 	 * Get the current list of servers.
-	 * 
+	 *
 	 * @param availableOnly if true, only live and available servers should be returned
 	 */
+	@Deprecated
 	public List<Server> getServerList(boolean availableOnly);
+
+	/**
+	 * @return Only the servers that are up and reachable.
+     */
+    public List<Server> getReachableServers();
+
+    /**
+     * @return All known servers, both reachable and unreachable.
+     */
+	public List<Server> getAllServers();
 }

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/NoOpLoadBalancer.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/NoOpLoadBalancer.java
@@ -65,5 +65,16 @@ public class NoOpLoadBalancer extends AbstractLoadBalancer {
 	public List<Server> getServerList(boolean availableOnly) {
 		// TODO Auto-generated method stub
 		return null;
-	}    
+	}
+
+    @Override
+    public List<Server> getReachableServers() {
+        return null;
+
+    }
+
+    @Override
+    public List<Server> getAllServers() {
+        return null;
+    }
 }

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/PredicateBasedRule.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/PredicateBasedRule.java
@@ -42,7 +42,7 @@ public abstract class PredicateBasedRule extends ClientConfigEnabledRoundRobinRu
     @Override
     public Server choose(Object key) {
         ILoadBalancer lb = getLoadBalancer();
-        Optional<Server> server = getPredicate().chooseRoundRobinAfterFiltering(lb.getServerList(false), key);
+        Optional<Server> server = getPredicate().chooseRoundRobinAfterFiltering(lb.getAllServers(), key);
         if (server.isPresent()) {
             return server.get();
         } else {

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/RandomRule.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/RandomRule.java
@@ -50,8 +50,8 @@ public class RandomRule extends AbstractLoadBalancerRule {
             if (Thread.interrupted()) {
                 return null;
             }
-            List<Server> upList = lb.getServerList(true);
-            List<Server> allList = lb.getServerList(false);
+            List<Server> upList = lb.getReachableServers();
+            List<Server> allList = lb.getAllServers();
 
             int serverCount = allList.size();
             if (serverCount == 0) {

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ResponseTimeWeightedRule.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ResponseTimeWeightedRule.java
@@ -155,7 +155,7 @@ public class ResponseTimeWeightedRule extends RoundRobinRule {
             if (Thread.interrupted()) {
                 return null;
             }
-            List<Server> allList = lb.getServerList(false);
+            List<Server> allList = lb.getAllServers();
 
             int serverCount = allList.size();
 
@@ -239,7 +239,7 @@ public class ResponseTimeWeightedRule extends RoundRobinRule {
                 }
                 double totalResponseTime = 0;
                 // find maximal 95% response time
-                for (Server server : nlb.getServerList(false)) {
+                for (Server server : nlb.getAllServers()) {
                     // this will automatically load the stats if not in cache
                     ServerStats ss = stats.getSingleServerStat(server);
                     totalResponseTime += ss.getResponseTimeAvg();
@@ -250,7 +250,7 @@ public class ResponseTimeWeightedRule extends RoundRobinRule {
                 
                 // create new list and hot swap the reference
                 List<Double> finalWeights = new ArrayList<Double>();
-                for (Server server : nlb.getServerList(false)) {
+                for (Server server : nlb.getAllServers()) {
                     ServerStats ss = stats.getSingleServerStat(server);
                     double weight = totalResponseTime - ss.getResponseTimeAvg();
                     weightSoFar += weight;

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/RoundRobinRule.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/RoundRobinRule.java
@@ -57,10 +57,10 @@ public class RoundRobinRule extends AbstractLoadBalancerRule {
         Server server = null;
         int count = 0;
         while (server == null && count++ < 10) {
-            List<Server> upList = lb.getServerList(AVAILABLE_ONLY_SERVERS);
-            List<Server> allList = lb.getServerList(ALL_SERVERS);
-            int upCount = upList.size();
-            int serverCount = allList.size();
+            List<Server> reachableServers = lb.getReachableServers();
+            List<Server> allServers = lb.getAllServers();
+            int upCount = reachableServers.size();
+            int serverCount = allServers.size();
 
             if ((upCount == 0) || (serverCount == 0)) {
                 log.warn("No up servers available from load balancer: " + lb);
@@ -68,7 +68,7 @@ public class RoundRobinRule extends AbstractLoadBalancerRule {
             }
 
             int nextServerIndex = incrementAndGetModulo(serverCount);
-            server = allList.get(nextServerIndex);
+            server = allServers.get(nextServerIndex);
 
             if (server == null) {
                 /* Transient. */
@@ -103,8 +103,9 @@ public class RoundRobinRule extends AbstractLoadBalancerRule {
             int next = (current + 1) % modulo;
             if (nextServerCyclicCounter.compareAndSet(current, next))
                 return next;
-            }
         }
+    }
+
     @Override
     public Server choose(Object key) {
         return choose(getLoadBalancer(), key);

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/WeightedResponseTimeRule.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/WeightedResponseTimeRule.java
@@ -165,7 +165,7 @@ public class WeightedResponseTimeRule extends RoundRobinRule {
             if (Thread.interrupted()) {
                 return null;
             }
-            List<Server> allList = lb.getServerList(false);
+            List<Server> allList = lb.getAllServers();
 
             int serverCount = allList.size();
 
@@ -252,7 +252,7 @@ public class WeightedResponseTimeRule extends RoundRobinRule {
                 }
                 double totalResponseTime = 0;
                 // find maximal 95% response time
-                for (Server server : nlb.getServerList(false)) {
+                for (Server server : nlb.getAllServers()) {
                     // this will automatically load the stats if not in cache
                     ServerStats ss = stats.getSingleServerStat(server);
                     totalResponseTime += ss.getResponseTimeAvg();
@@ -263,7 +263,7 @@ public class WeightedResponseTimeRule extends RoundRobinRule {
                 
                 // create new list and hot swap the reference
                 List<Double> finalWeights = new ArrayList<Double>();
-                for (Server server : nlb.getServerList(false)) {
+                for (Server server : nlb.getAllServers()) {
                     ServerStats ss = stats.getSingleServerStat(server);
                     double weight = totalResponseTime - ss.getResponseTimeAvg();
                     weightSoFar += weight;

--- a/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/DynamicServerListLoadBalancerTest.java
+++ b/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/DynamicServerListLoadBalancerTest.java
@@ -79,7 +79,7 @@ public class DynamicServerListLoadBalancerTest {
             assertTrue(MyServerList.latch.await(2, TimeUnit.SECONDS));
         } catch (InterruptedException e) { // NOPMD
         }
-        assertEquals(lb.getServerList(false), MyServerList.list);
+        assertEquals(lb.getAllServers(), MyServerList.list);
         lb.stopServerListRefreshing();
         Thread.sleep(1000);
         int count = MyServerList.counter.get();

--- a/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/ServerStatusChangeListenerTest.java
+++ b/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/ServerStatusChangeListenerTest.java
@@ -20,17 +20,33 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.core.AllOf.allOf;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Before;
 import org.junit.Test;
 
 public class ServerStatusChangeListenerTest {
+
+    /**
+     * A load balancer that has all the functionality of the Base one except it does not
+     * schedule any ping tasks that can concurrently update the state of the LB by either
+     * causing forced pings to be dropped or changing the expected state of the test before
+     * we assert our invariants.
+     */
+    private class NoPingTaskLoadBalancer extends BaseLoadBalancer {
+        @Override
+        void setupPingTask() {}
+    }
+
     private final Server server1 = new Server("server1");
     private final Server server2 = new Server("server2");
     
@@ -39,7 +55,7 @@ public class ServerStatusChangeListenerTest {
 
     @Before
     public void setupLoadbalancerAndListener() {
-        lb = new BaseLoadBalancer();
+        lb = new NoPingTaskLoadBalancer();
         lb.setServersList(asList(server1, server2));
         serversReceivedByListener = new AtomicReference<List<Server>>();
         lb.addServerStatusChangeListener(new ServerStatusChangeListener() {
@@ -66,18 +82,22 @@ public class ServerStatusChangeListenerTest {
         assertThat(serversReceivedByListener.get(), is(singletonList(server2)));
     }
 
-
     @Test
-    public void changeServerStatusByPingShouldBeReceivedByListener() {
+    public void changeServerStatusByPingShouldBeReceivedByListener() throws InterruptedException {
         final PingConstant ping = new PingConstant();
-        lb.setPing(ping);
-
+        // Start with a ping where both servers are down.
         ping.setConstant(false);
+        lb.setPing(ping);
         lb.forceQuickPing();
+        // We should see that the servers that changed status are both server1 and 2.
         assertThat(serversReceivedByListener.get(), allOf(hasItem(server1), hasItem(server2)));
 
+        // Bring both servers back up.
         ping.setConstant(true);
+        // Clear the list so we can see the change-list is non-empty after the listener is called.
+        serversReceivedByListener.set(null);
         lb.forceQuickPing();
+        assertFalse(serversReceivedByListener.get().isEmpty());
         assertThat(serversReceivedByListener.get(), allOf(hasItem(server1), hasItem(server2)));
     }
 

--- a/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/SimpleRoundRobinLBTest.java
+++ b/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/SimpleRoundRobinLBTest.java
@@ -63,7 +63,6 @@ public class SimpleRoundRobinLBTest {
 			Thread.sleep(5000);
 		} catch (InterruptedException e) {
 		}
-		System.out.println(lb.getServerList(true));
 	}
 	
 	@AfterClass

--- a/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/SubsetFilterTest.java
+++ b/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/SubsetFilterTest.java
@@ -174,7 +174,7 @@ public class SubsetFilterTest {
             e.printStackTrace();
         }
         lb.updateListOfServers();
-        List<Server> filtered = lb.getServerList(false);
+        List<Server> filtered = lb.getAllServers();
         // first filtering, should get 5 servers 
         assertEquals(filtered.size(), 5);
         
@@ -203,7 +203,7 @@ public class SubsetFilterTest {
         // filter again, this time some servers will be eliminated
         serverList.setServerList(list);
         lb.updateListOfServers();
-        filtered = lb.getServerList(false);
+        filtered = lb.getAllServers();
         
         assertEquals(5, filtered.size());
         assertTrue(!filtered.contains(s1));
@@ -215,7 +215,7 @@ public class SubsetFilterTest {
         // Not enough healthy servers, just get whatever is available
         serverList.setServerList(Lists.newArrayList(filtered));
         lb.updateListOfServers();
-        List<Server> lastFiltered = lb.getServerList(false);
+        List<Server> lastFiltered = lb.getAllServers();
         assertEquals(5, lastFiltered.size());
 
     }

--- a/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/ZoneAwareLoadBalancerTest.java
+++ b/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/ZoneAwareLoadBalancerTest.java
@@ -279,7 +279,7 @@ public class ZoneAwareLoadBalancerTest {
         servers.add(createServer(1, "b"));
         servers.add(createServer(2, "b"));
         balancer.setServersList(servers);
-        assertTrue(balancer.getLoadBalancer("us-east-1c").getServerList(false).isEmpty());
+        assertTrue(balancer.getLoadBalancer("us-east-1c").getAllServers().isEmpty());
         AvailabilityFilteringRule rule = (AvailabilityFilteringRule) balancer.getLoadBalancer("us-east-1c").getRule();
         assertEquals(0, rule.getAvailableServersCount());
     }

--- a/ribbon-transport/src/test/java/com/netflix/ribbon/transport/netty/http/DiscoveryLoadBalancerTest.java
+++ b/ribbon-transport/src/test/java/com/netflix/ribbon/transport/netty/http/DiscoveryLoadBalancerTest.java
@@ -49,7 +49,7 @@ public class DiscoveryLoadBalancerTest extends MockedDiscoveryServerListTest {
                 .set(IClientConfigKey.Keys.NIWSServerListClassName, DiscoveryEnabledNIWSServerList.class.getName());
         LoadBalancingHttpClient<ByteBuf, ByteBuf> client = RibbonTransport.newHttpClient(config);
         LoadBalancerContext lbContext = client.getLoadBalancerContext();
-        List<Server> serverList = lbContext.getLoadBalancer().getServerList(false);
+        List<Server> serverList = lbContext.getLoadBalancer().getAllServers();
         assertEquals(getMockServerList(), serverList);
     }
 }


### PR DESCRIPTION
Replaced the AtomicLong implementation of our cyclic
counting code with an AtomicInteger that rotates back to 0
if it hits its max value so we do the "right thing".

Also did a bit of clean-up and fixed one of the unit tests that was unstable.