### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/ribbon-httpclient/build.gradle
+++ b/ribbon-httpclient/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     compile project(':ribbon-core')
     compile project(':ribbon-loadbalancer')
-    compile 'commons-collections:commons-collections:3.2.1'        
+    compile 'commons-collections:commons-collections:3.2.2'        
     compile 'org.apache.httpcomponents:httpclient:4.2.1'
     compile 'com.google.code.findbugs:annotations:2.0.0' 
     compile "com.sun.jersey:jersey-client:${jersey_version}"


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
