### PR TITLE
Refactor sychronization in client factories

### DIFF
--- a/ribbon-httpclient/src/test/java/com/netflix/client/ClientFactoryTest.java
+++ b/ribbon-httpclient/src/test/java/com/netflix/client/ClientFactoryTest.java
@@ -20,13 +20,19 @@ package com.netflix.client;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.Executors;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.netflix.client.config.DefaultClientConfigImpl;
+import com.netflix.client.config.IClientConfig;
 import com.netflix.config.ConfigurationManager;
 import com.netflix.loadbalancer.ConfigurationBasedServerList;
 import com.netflix.loadbalancer.DynamicServerListLoadBalancer;
@@ -35,11 +41,13 @@ import com.netflix.niws.client.http.RestClient;
 
 public class ClientFactoryTest {
 	
+    private static IClientConfig config;
 	private static RestClient client;
 	
 	@BeforeClass
 	public static void init() {
 		ConfigurationManager.getConfigInstance().setProperty("junit.ribbon.listOfServers", "www.example1.come:80,www.example2.come:80,www.example3.come:80");
+		config = ClientFactory.getNamedConfig("junit", DefaultClientConfigImpl.class);
 		client = (RestClient) ClientFactory.getNamedClient("junit");
 	}
 	
@@ -59,5 +67,90 @@ public class ClientFactoryTest {
 		}
 		assertEquals(expected, result);
 	}
+	
+    @Test
+	public void testConcurrentClientLoading() {
+        
+        int concurrencyCount = 20;
+	    
+	    long sequentialStart = System.currentTimeMillis();
+	    for (int i = 0; i < concurrencyCount; i++) {
+	        final String name = "junit_sequential_"+i;
+	        ClientFactory.getNamedClient(name);
+	        System.out.println(name + " initialized");
+	    }
+	    long sequentialDuration = System.currentTimeMillis() - sequentialStart;
+	    
+	    final ExecutorCompletionService<Boolean> executorCompletionService = new ExecutorCompletionService<Boolean>(Executors.newFixedThreadPool(concurrencyCount));
+	    
+	    long parallelStart = System.currentTimeMillis();
+        for (int i = 0; i < concurrencyCount; i++) {
+            executorCompletionService.submit(new ClientTask(i), true);
+        }
+        
+        for (int i = 0; i < concurrencyCount; i++) {
+            try {
+                executorCompletionService.take().get();
+            } catch (InterruptedException | ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        long parallelDuration = System.currentTimeMillis() - parallelStart;
+        
+        assertTrue("parallel loading was not faster", parallelDuration < sequentialDuration);
+	}
+    
+    @Test
+    public void testRegisterDuplicateClient() throws ClientException {
+        String name = "duplicateClient";
+        ClientFactory.registerClientFromProperties(name, config);
+        
+        try {
+            ClientFactory.registerClientFromProperties(name, config);
+            fail("ClientException was not thrown");
+        } catch (ClientException e) {
+            // Do Nothing - Exception was expected
+        }
+    }
+    
+    @Test
+    public void testRegisterDuplicateLoadBalancerConfig() throws ClientException {
+        String name = "duplicateLBConfig";
+        ClientFactory.registerNamedLoadBalancerFromclientConfig(name, config);
+        
+        try {
+            ClientFactory.registerNamedLoadBalancerFromclientConfig(name, config);
+            fail("ClientException was not thrown");
+        } catch (ClientException e) {
+            // Do Nothing - Exception was expected
+        }
+    }
+    
+    @Test
+    public void testRegisterDuplicateLoadBalancerProperties() throws ClientException {
+        String name = "duplicateLBProp";
+        ConfigurationManager.getConfigInstance().setProperty(name+ ".ribbon.listOfServers", "www.example1.come:80,www.example2.come:80,www.example3.come:80");
+        ClientFactory.registerNamedLoadBalancerFromProperties(name, DefaultClientConfigImpl.class);
+        
+        try {
+            ClientFactory.registerNamedLoadBalancerFromProperties(name, DefaultClientConfigImpl.class);
+            fail("ClientException was not thrown");
+        } catch (ClientException e) {
+            // Do Nothing - Exception was expected
+        }
+    }
+    
+    private static class ClientTask implements Runnable {
+        
+        final String name;
+        ClientTask(final int instance) {
+            name = "junit_parallel_"+instance;
+        }
+
+        @Override
+        public void run() {
+            ClientFactory.getNamedClient(name); 
+        }
+    }
 
 }


### PR DESCRIPTION
Implementation for #269

Refactored `NFHttpClientFactory ` and `ClientFactory` to synchronize on the name of the client being registered instead of the entire class instance.