### PR TITLE
Issue 290

### DIFF
--- a/ribbon-transport/src/main/java/com/netflix/ribbon/transport/netty/LoadBalancingRxClientWithPoolOptions.java
+++ b/ribbon-transport/src/main/java/com/netflix/ribbon/transport/netty/LoadBalancingRxClientWithPoolOptions.java
@@ -17,7 +17,6 @@
  */
 package com.netflix.ribbon.transport.netty;
 
-import io.reactivex.netty.client.CompositePoolLimitDeterminationStrategy;
 import io.reactivex.netty.client.MaxConnectionsBasedStrategy;
 import io.reactivex.netty.client.PoolLimitDeterminationStrategy;
 import io.reactivex.netty.client.RxClient;
@@ -35,7 +34,6 @@ import com.netflix.loadbalancer.ILoadBalancer;
 import com.netflix.loadbalancer.LoadBalancerBuilder;
 
 public abstract class LoadBalancingRxClientWithPoolOptions<I, O, T extends RxClient<I, O>> extends LoadBalancingRxClient<I, O, T>{
-    protected CompositePoolLimitDeterminationStrategy poolStrategy;
     protected MaxConnectionsBasedStrategy globalStrategy;
     protected int idleConnectionEvictionMills;
     protected ScheduledExecutorService poolCleanerScheduler;
@@ -61,12 +59,8 @@ public abstract class LoadBalancingRxClientWithPoolOptions<I, O, T extends RxCli
             this.poolCleanerScheduler = poolCleanerScheduler;
             int maxTotalConnections = config.get(IClientConfigKey.Keys.MaxTotalConnections,
                     DefaultClientConfigImpl.DEFAULT_MAX_TOTAL_CONNECTIONS);
-            int maxConnections = config.get(Keys.MaxConnectionsPerHost, DefaultClientConfigImpl.DEFAULT_MAX_CONNECTIONS_PER_HOST);
-            MaxConnectionsBasedStrategy perHostStrategy = new DynamicPropertyBasedPoolStrategy(maxConnections,
-                    config.getClientName() + "." + config.getNameSpace() + "." + CommonClientConfigKey.MaxConnectionsPerHost);
-            globalStrategy = new DynamicPropertyBasedPoolStrategy(maxTotalConnections, 
+            globalStrategy = new DynamicPropertyBasedPoolStrategy(maxTotalConnections,
                     config.getClientName() + "." + config.getNameSpace() + "." + CommonClientConfigKey.MaxTotalConnections);
-            poolStrategy = new CompositePoolLimitDeterminationStrategy(perHostStrategy, globalStrategy);
             idleConnectionEvictionMills = config.get(Keys.ConnIdleEvictTimeMilliSeconds, DefaultClientConfigImpl.DEFAULT_CONNECTIONIDLE_TIME_IN_MSECS);
         }
     }

--- a/ribbon-transport/src/main/java/com/netflix/ribbon/transport/netty/http/LoadBalancingHttpClient.java
+++ b/ribbon-transport/src/main/java/com/netflix/ribbon/transport/netty/http/LoadBalancingHttpClient.java
@@ -18,6 +18,7 @@
 
 package com.netflix.ribbon.transport.netty.http;
 
+import com.netflix.ribbon.transport.netty.DynamicPropertyBasedPoolStrategy;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelOption;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -25,6 +26,7 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.netty.client.ClientMetricsEvent;
 import io.reactivex.netty.client.CompositePoolLimitDeterminationStrategy;
+import io.reactivex.netty.client.MaxConnectionsBasedStrategy;
 import io.reactivex.netty.client.RxClient;
 import io.reactivex.netty.contexts.RxContexts;
 import io.reactivex.netty.contexts.http.HttpRequestIdProvider;
@@ -495,6 +497,10 @@ public class LoadBalancingHttpClient<I, O> extends LoadBalancingRxClientWithPool
                 .channelOption(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeout)
                 .config(builder.build());
         if (isPoolEnabled()) {
+            int maxConnections = this.clientConfig.get(IClientConfigKey.Keys.MaxConnectionsPerHost, DefaultClientConfigImpl.DEFAULT_MAX_CONNECTIONS_PER_HOST);
+            MaxConnectionsBasedStrategy perHostStrategy = new DynamicPropertyBasedPoolStrategy(maxConnections,
+                    this.clientConfig.getClientName() + "." + this.clientConfig.getNameSpace() + "." + CommonClientConfigKey.MaxConnectionsPerHost);
+            CompositePoolLimitDeterminationStrategy poolStrategy = new CompositePoolLimitDeterminationStrategy(perHostStrategy, globalStrategy);
             clientBuilder
                 .withConnectionPoolLimitStrategy(poolStrategy)
                 .withIdleConnectionsTimeoutMillis(idleConnectionEvictionMills)


### PR DESCRIPTION
- Initializing perHostStrategy per client rather than a global one so that each client has its own count of connections