### PR TITLE
Correct the Host header to also carry the port number ...

### DIFF
--- a/ribbon-transport/src/main/java/com/netflix/ribbon/transport/netty/http/LoadBalancingHttpClient.java
+++ b/ribbon-transport/src/main/java/com/netflix/ribbon/transport/netty/http/LoadBalancingHttpClient.java
@@ -308,7 +308,7 @@ public class LoadBalancingHttpClient<I, O> extends LoadBalancingRxClientWithPool
             @Override
             public Observable<HttpClientResponse<O>> call(Server server) {
                 HttpClient<I,O> rxClient = getOrCreateRxClient(server);
-                setHostHeader(request, server.getHost());
+                setHostHeader(request, server.getHostPort());
                 
                 Observable<HttpClientResponse<O>> o;
                 if (rxClientConfig != null) {


### PR DESCRIPTION
 when creating the `ServerOperation` from `HttpClientRequest`.

Section 14.23 of the HTTP spec specifies that the port # needs to be included in the `Host:` header when contacting a non-80 port.

previously, only the host was transmitted in all cases, which hence is against specification if the port being contacted is different from 80.