### PR TITLE
Avoid using ClassCastException to control property loading

### DIFF
--- a/ribbon-core/src/main/java/com/netflix/client/config/DefaultClientConfigImpl.java
+++ b/ribbon-core/src/main/java/com/netflix/client/config/DefaultClientConfigImpl.java
@@ -883,9 +883,9 @@ public class DefaultClientConfigImpl implements IClientConfig {
             return null;
         }
         Class<T> type = key.type();
-        try {
+        if (type.isInstance(obj)) {
             return type.cast(obj);
-        } catch (ClassCastException e) {
+        } else {
             if (obj instanceof String) {
                 String stringValue = (String) obj;
                 if (Integer.class.equals(type)) {
@@ -902,9 +902,9 @@ public class DefaultClientConfigImpl implements IClientConfig {
                     return (T) TimeUnit.valueOf(stringValue);
                 }
                 throw new IllegalArgumentException("Unable to convert string value to desired type " + type);
-            } else {
-               throw e;
             }
+             
+            throw new IllegalArgumentException("Unable to convert value to desired type " + type);
         }
     }
 


### PR DESCRIPTION
When loading dynamic properties, any property that is not a `String` results in a `ClassCastException` being created to control cast flow. An `isInstance` check can be used to avoid the creation of an exception.

```
java.lang.Throwable.<init>(String)	
   java.lang.Exception.<init>(String)	
      java.lang.RuntimeException.<init>(String)	
         java.lang.ClassCastException.<init>(String)	
            java.lang.Class.cast(Object)	
               com.netflix.client.config.DefaultClientConfigImpl.get(IClientConfigKey)	
                  com.netflix.client.config.DefaultClientConfigImpl.get(IClientConfigKey, Object)	
                     com.netflix.niws.client.http.RestClient.getRequestSpecificRetryHandler(HttpRequest, IClientConfig)	
                        com.netflix.niws.client.http.RestClient.getRequestSpecificRetryHandler(ClientRequest, IClientConfig)	
                           com.netflix.client.AbstractLoadBalancerAwareClient.executeWithLoadBalancer(ClientRequest, IClientConfig)	
                              com.netflix.client.AbstractLoadBalancerAwareClient.executeWithLoadBalancer(ClientRequest)	
```