### PR TITLE
Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ HttpRequestTemplate<ByteBuf> recommendationsByUserIdTemplate = httpResourceGroup
             .withResponseValidator(new RecommendationServiceResponseValidator())
             .build();
 Observable<ByteBuf> result = recommendationsByUserIdTemplate.requestBuilder()
-                        .withRequestProperty("userId", “user1")
+                        .withRequestProperty("userId", "user1")
                         .build()
                         .observe();
 ```


### PR DESCRIPTION
Replaced “ (U+201C LEFT DOUBLE QUOTATION MARK) with " (U+0022 QUOTATION MARK).
