### PR TITLE
Remove catch throwables

### DIFF
--- a/ribbon-core/src/main/java/com/netflix/client/config/DefaultClientConfigImpl.java
+++ b/ribbon-core/src/main/java/com/netflix/client/config/DefaultClientConfigImpl.java
@@ -17,23 +17,23 @@
 */
 package com.netflix.client.config;
 
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-
-import org.apache.commons.configuration.AbstractConfiguration;
-import org.apache.commons.configuration.Configuration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.base.Strings;
 import com.netflix.client.VipAddressResolver;
 import com.netflix.config.ConfigurationManager;
 import com.netflix.config.DynamicProperty;
 import com.netflix.config.DynamicPropertyFactory;
 import com.netflix.config.DynamicStringProperty;
+
+import org.apache.commons.configuration.AbstractConfiguration;
+import org.apache.commons.configuration.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Default client configuration that loads properties from Archaius's ConfigurationManager.
@@ -631,16 +631,16 @@ public class DefaultClientConfigImpl implements IClientConfig {
             synchronized (this) {
                 if (resolver == null) {
                     try {
-                        resolver = (VipAddressResolver) Class.forName(
-                                (String) getProperty(CommonClientConfigKey.VipAddressResolverClassName)).newInstance();
-                    } catch (InstantiationException|IllegalAccessException|ClassNotFoundException e) {
-                        LOG.error("Cannot instantiate VipAddressResolver", e);
-		    }
+                        resolver = (VipAddressResolver) Class
+                                .forName((String) getProperty(CommonClientConfigKey.VipAddressResolverClassName))
+                                .newInstance();
+                    } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+                        throw new RuntimeException("Cannot instantiate VipAddressResolver", e);
+                    }
                 }
             }
         }
         return resolver;
-
     }
 
     @Override

--- a/ribbon-core/src/main/java/com/netflix/client/config/DefaultClientConfigImpl.java
+++ b/ribbon-core/src/main/java/com/netflix/client/config/DefaultClientConfigImpl.java
@@ -17,23 +17,23 @@
 */
 package com.netflix.client.config;
 
-import com.google.common.base.Strings;
-import com.netflix.client.VipAddressResolver;
-import com.netflix.config.ConfigurationManager;
-import com.netflix.config.DynamicProperty;
-import com.netflix.config.DynamicPropertyFactory;
-import com.netflix.config.DynamicStringProperty;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.configuration.AbstractConfiguration;
 import org.apache.commons.configuration.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
+import com.google.common.base.Strings;
+import com.netflix.client.VipAddressResolver;
+import com.netflix.config.ConfigurationManager;
+import com.netflix.config.DynamicProperty;
+import com.netflix.config.DynamicPropertyFactory;
+import com.netflix.config.DynamicStringProperty;
 
 /**
  * Default client configuration that loads properties from Archaius's ConfigurationManager.
@@ -633,9 +633,9 @@ public class DefaultClientConfigImpl implements IClientConfig {
                     try {
                         resolver = (VipAddressResolver) Class.forName(
                                 (String) getProperty(CommonClientConfigKey.VipAddressResolverClassName)).newInstance();
-                    } catch (Throwable e) {
+                    } catch (InstantiationException|IllegalAccessException|ClassNotFoundException e) {
                         LOG.error("Cannot instantiate VipAddressResolver", e);
-                    }
+		    }
                 }
             }
         }

--- a/ribbon-evcache/src/main/java/com/netflix/ribbon/evache/EvCacheProvider.java
+++ b/ribbon-evcache/src/main/java/com/netflix/ribbon/evache/EvCacheProvider.java
@@ -22,14 +22,15 @@ import com.netflix.ribbon.CacheProvider;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import rx.Observable;
-import rx.Observable.OnSubscribe;
-import rx.Subscriber;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+
+import rx.Observable;
+import rx.Observable.OnSubscribe;
+import rx.Subscriber;
 
 /**
  * @author Tomasz Bak
@@ -104,10 +105,9 @@ public class EvCacheProvider<T> implements CacheProvider<T> {
                     } else if (future.isDone()) {
                         try {
                             handleCompletedFuture(future, subscriber);
-                        } catch (Error e) {
-                            throw e;
-                        } catch (Throwable e) {
-                            LOGGER.warn("unexpected error during checking future result", e);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new RuntimeException(e);
                         } finally {
                             futureMap.remove(future);
                         }

--- a/ribbon-loadbalancer/src/main/java/com/netflix/client/ClientFactory.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/client/ClientFactory.java
@@ -17,18 +17,18 @@
 */
 package com.netflix.client;
 
-import java.lang.reflect.InvocationTargetException;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.netflix.client.config.CommonClientConfigKey;
 import com.netflix.client.config.DefaultClientConfigImpl;
 import com.netflix.client.config.IClientConfig;
 import com.netflix.loadbalancer.ILoadBalancer;
 import com.netflix.servo.monitor.Monitors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * A factory that creates client, load balancer and client configuration instances from properties. It also keeps mappings of client names to 
@@ -166,8 +166,7 @@ public class ClientFactory {
             String loadBalancerClassName = (String) clientConfig.getProperty(CommonClientConfigKey.NFLoadBalancerClassName);
             lb = (ILoadBalancer) ClientFactory.instantiateInstanceWithClientConfig(loadBalancerClassName, clientConfig);                                    
             namedLBMap.put(name, lb);            
-            logger.info("Client:" + name
-                    + " instantiated a LoadBalancer:" + lb.toString());
+            logger.info("Client: {} instantiated a LoadBalancer: {}", name, lb);
             return lb;
         } catch (Exception e) {           
            throw new ClientException("Unable to instantiate/associate LoadBalancer with Client:" + name, e);
@@ -210,7 +209,10 @@ public class ClientFactory {
     		    if (clazz.getConstructor(IClientConfig.class) != null) {
     		    	return clazz.getConstructor(IClientConfig.class).newInstance(clientConfig);
     		    }
-    		} catch (NoSuchMethodException | SecurityException | IllegalArgumentException | InvocationTargetException ignore) { // NOPMD   			
+    		} catch (NoSuchMethodException ignored) {
+    		    // OK for a class to not take an IClientConfig
+    		} catch (SecurityException | IllegalArgumentException | InvocationTargetException e) { 
+    		    logger.warn("Error getting/invoking IClientConfig constructor of {}", className, e);
     		}    		
     	}
     	logger.warn("Class " + className + " neither implements IClientConfigAware nor provides a constructor with IClientConfig as the parameter. Only default constructor will be used.");
@@ -230,25 +232,25 @@ public class ClientFactory {
      * Get the client configuration given the name or create one with clientConfigClass if it does not exist. An instance of IClientConfig
      * is created and {@link IClientConfig#loadProperties(String)} will be called.
      */
-	public static IClientConfig getNamedConfig(String name, Class<? extends IClientConfig> clientConfigClass) {
-		IClientConfig config = namedConfig.get(name);
-		if (config != null) {
-			return config;
-		} else {
-			try {
-				config = (IClientConfig) clientConfigClass.newInstance();
-				config.loadProperties(name);
-			} catch (InstantiationException | IllegalAccessException e) {
-				logger.error("Unable to create named client config '{}' instance for config class {}", name,
-				        clientConfigClass, e);
-				return null;
-			}
-			config.loadProperties(name);
-			IClientConfig old = namedConfig.putIfAbsent(name, config);
-			if (old != null) {
-				config = old;
-			}
-			return config;
-		}
-	}
+    public static IClientConfig getNamedConfig(String name, Class<? extends IClientConfig> clientConfigClass) {
+        IClientConfig config = namedConfig.get(name);
+        if (config != null) {
+            return config;
+        } else {
+            try {
+                config = (IClientConfig) clientConfigClass.newInstance();
+                config.loadProperties(name);
+            } catch (InstantiationException | IllegalAccessException e) {
+                logger.error("Unable to create named client config '{}' instance for config class {}", name,
+                        clientConfigClass, e);
+                return null;
+            }
+            config.loadProperties(name);
+            IClientConfig old = namedConfig.putIfAbsent(name, config);
+            if (old != null) {
+                config = old;
+            }
+            return config;
+        }
+    }
 }

--- a/ribbon-loadbalancer/src/main/java/com/netflix/client/PrimeConnections.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/client/PrimeConnections.java
@@ -344,8 +344,8 @@ public class PrimeConnections {
         boolean success = false;
         do {
             try {
-                logger.debug("Executing PrimeConnections request to server " + s + " with path " + primeConnectionsURIPath
-                        + ", tryNum=" + tryNum);
+                logger.debug("Executing PrimeConnections request to server {} with path {}, tryNum={}",
+                	s, primeConnectionsURIPath, tryNum);
                 success = connector.connect(s, primeConnectionsURIPath);
                 successCounter.increment();
                 break;
@@ -357,20 +357,19 @@ public class PrimeConnections {
                 lastException = e;
                 sleepBeforeRetry(tryNum);
             } 
-            logger.debug("server:" + s + ", result=" + success + ", tryNum="
-                    + tryNum + ", maxRetries=" + maxRetries);
+            logger.debug("server:{}, result={}, tryNum={}, maxRetries={}", s, success, tryNum, maxRetries);
             tryNum++;
         } while (!success && (tryNum <= maxRetries));
         // set the alive flag so that it can be used by load balancers
         if (listener != null) {
             try {
                 listener.primeCompleted(s, lastException);
-            } catch (Throwable e) {
-                logger.error("Error calling PrimeComplete listener", e);
+            } catch (Error e) {
+                logger.error("Error calling PrimeComplete listener for server '{}'", s.getHost(), e);
             }
         }
-        logger.debug("Either done, or quitting server:" + s + ", result="
-                + success + ", tryNum=" + tryNum + ", maxRetries=" + maxRetries);        
+        logger.debug("Either done, or quitting server:{}, result={}, tryNum={}, maxRetries={}", 
+        	s, success, tryNum, maxRetries);
         return success;
     }
 

--- a/ribbon-loadbalancer/src/main/java/com/netflix/client/PrimeConnections.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/client/PrimeConnections.java
@@ -364,7 +364,7 @@ public class PrimeConnections {
         if (listener != null) {
             try {
                 listener.primeCompleted(s, lastException);
-            } catch (Error e) {
+            } catch (Exception e) {
                 logger.error("Error calling PrimeComplete listener for server '{}'", s.getHost(), e);
             }
         }

--- a/ribbon-loadbalancer/src/main/java/com/netflix/client/PrimeConnections.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/client/PrimeConnections.java
@@ -348,6 +348,7 @@ public class PrimeConnections {
                 	s, primeConnectionsURIPath, tryNum);
                 success = connector.connect(s, primeConnectionsURIPath);
                 successCounter.increment();
+                lastException = null;
                 break;
             } catch (Exception e) {
                 // It does not really matter if there was an exception,
@@ -365,7 +366,7 @@ public class PrimeConnections {
             try {
                 listener.primeCompleted(s, lastException);
             } catch (Exception e) {
-                logger.error("Error calling PrimeComplete listener for server '{}'", s.getHost(), e);
+                logger.error("Error calling PrimeComplete listener for server '{}'", s, e);
             }
         }
         logger.debug("Either done, or quitting server:{}, result={}, tryNum={}, maxRetries={}", 

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/AbstractServerList.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/AbstractServerList.java
@@ -49,7 +49,7 @@ public abstract class AbstractServerList<T extends Server> implements ServerList
             AbstractServerListFilter<T> abstractNIWSServerListFilter = 
                     (AbstractServerListFilter<T>) ClientFactory.instantiateInstanceWithClientConfig(niwsServerListFilterClassName, niwsClientConfig);
             return abstractNIWSServerListFilter;
-        } catch (Throwable e) {
+        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
             throw new ClientException(
                     ClientException.ErrorType.CONFIGURATION,
                     "Unable to get an instance of CommonClientConfigKey.NIWSServerListFilterClassName. Configured class:"

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/BaseLoadBalancer.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/BaseLoadBalancer.java
@@ -19,22 +19,6 @@ package com.netflix.loadbalancer;
 
 import static java.util.Collections.singleton;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.collect.ImmutableList;
 import com.netflix.client.ClientFactory;
 import com.netflix.client.IClientConfigAware;
@@ -47,6 +31,22 @@ import com.netflix.servo.annotations.Monitor;
 import com.netflix.servo.monitor.Counter;
 import com.netflix.servo.monitor.Monitors;
 import com.netflix.util.concurrent.ShutdownEnabledTimer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * A basic implementation of the load balancer where an arbitrary list of
@@ -503,7 +503,7 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
                    for (ServerListChangeListener l: changeListeners) {
                        try {
                            l.serverListChanged(oldList, newList);
-                       } catch (Error e) {
+                       } catch (Exception e) {
                            logger.error("LoadBalancer [{}]: Error invoking server list change listener", name, e);
                        }
                    }
@@ -625,7 +625,7 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
         public void run() {
             try {
             	new Pinger(pingStrategy).runPinger();
-            } catch (Error e) {
+            } catch (Exception e) {
                 logger.error("LoadBalancer [{}]: Error pinging", name, e);
             }
         }
@@ -699,7 +699,7 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
 
                 notifyServerStatusChangeListener(changedServers);
 
-            } catch (Error e) {
+            } catch (Exception e) {
                 logger.error("LoadBalancer [{}] : Error running the Pinger", name, e);
             } finally {
                 pingInProgress.set(false);
@@ -712,7 +712,7 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
             for (ServerStatusChangeListener listener : serverStatusListeners) {
                 try {
                     listener.serverStatusChanged(changedServers);
-                } catch (Error e) {
+                } catch (Exception e) {
                     logger.error("LoadBalancer [{}]: Error invoking server status change listener", name, e);
                 }
             }
@@ -738,8 +738,8 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
         } else {
             try {
                 return rule.choose(key);
-            } catch (Error t) {
-                throw new Error("Error choosing server for key " + key);
+            } catch (Exception e) {
+                throw new RuntimeException("Error choosing server for key " + key, e);
             }
         }
     }
@@ -752,8 +752,8 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
             try {
                 Server svr = rule.choose(key);
                 return ((svr == null) ? null : svr.getId());
-            } catch (Error t) {
-            	logger.error("LoadBalancer [{}]:  Error choosing server for key '{}'", name, key, t);
+            } catch (Exception e) {
+            	logger.error("LoadBalancer [{}]:  Error choosing server for key '{}'", name, key, e);
                 return null;
             }
         }
@@ -815,7 +815,7 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
         
         try {
         	new Pinger(pingStrategy).runPinger();
-        } catch (Error e) {
+        } catch (Exception e) {
             logger.error("LoadBalancer [{}]: Error running forceQuickPing()", name, e);
         }
     }
@@ -904,7 +904,7 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
                     if (ping != null) {
                         results[i] = ping.isAlive(servers[i]);
                     }
-                } catch (Error e) {
+                } catch (Exception e) {
                     logger.error("Exception while pinging Server: '{}'", servers[i], e);
                 }
             }

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/BaseLoadBalancer.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/BaseLoadBalancer.java
@@ -781,7 +781,7 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
         }
 
         Lock writeLock = upServerLock.writeLock();
-
+    	writeLock.lock();
         try {
             final List<Server> changedServers = new ArrayList<Server>();
 

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/LoadBalancerContext.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/LoadBalancerContext.java
@@ -245,12 +245,18 @@ public class LoadBalancerContext implements IClientConfigAware {
     }
 
     private void recordStats(ServerStats stats, long responseTime) {
+    	if (stats == null) {
+    		return;
+    	}
         stats.decrementActiveRequestsCount();
         stats.incrementNumRequests();
         stats.noteResponseTime(responseTime);
     }
 
     protected void noteRequestCompletion(ServerStats stats, Object response, Throwable e, long responseTime) {
+    	if (stats == null) {
+    		return;
+    	}
         noteRequestCompletion(stats, response, e, responseTime, null);
     }
     
@@ -260,6 +266,9 @@ public class LoadBalancerContext implements IClientConfigAware {
      * to update related stats.  
      */
     public void noteRequestCompletion(ServerStats stats, Object response, Throwable e, long responseTime, RetryHandler errorHandler) {
+    	if (stats == null) {
+    		return;
+    	}
         try {
             recordStats(stats, responseTime);
             RetryHandler callErrorHandler = errorHandler == null ? getRetryHandler() : errorHandler;
@@ -283,6 +292,9 @@ public class LoadBalancerContext implements IClientConfigAware {
      * to update related stats.  
      */
     protected void noteError(ServerStats stats, ClientRequest request, Throwable e, long responseTime) {
+    	if (stats == null) {
+    		return;
+    	}
         try {
             recordStats(stats, responseTime);
             RetryHandler errorHandler = getRetryHandler();
@@ -304,6 +316,9 @@ public class LoadBalancerContext implements IClientConfigAware {
      * to update related stats.  
      */
     protected void noteResponse(ServerStats stats, ClientRequest request, Object response, long responseTime) {
+    	if (stats == null) {
+    		return;
+    	}
         try {
             recordStats(stats, responseTime);
             RetryHandler errorHandler = getRetryHandler();

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/LoadBalancerContext.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/LoadBalancerContext.java
@@ -282,7 +282,7 @@ public class LoadBalancerContext implements IClientConfigAware {
                     stats.clearSuccessiveConnectionFailureCount();
                 }
             }
-        } catch (Error ex) {
+        } catch (Exception ex) {
             logger.error("Error noting stats for client {}", clientName, ex);
         }            
     }
@@ -306,7 +306,7 @@ public class LoadBalancerContext implements IClientConfigAware {
                     stats.clearSuccessiveConnectionFailureCount();
                 }
             }
-        } catch (Error ex) {
+        } catch (Exception ex) {
             logger.error("Error noting stats for client {}", clientName, ex);
         }            
     }
@@ -325,7 +325,7 @@ public class LoadBalancerContext implements IClientConfigAware {
             if (errorHandler != null && response != null) {
                 stats.clearSuccessiveConnectionFailureCount();
             } 
-        } catch (Error ex) {
+        } catch (Exception ex) {
             logger.error("Error noting stats for client {}", clientName, ex);
         }            
     }
@@ -339,7 +339,7 @@ public class LoadBalancerContext implements IClientConfigAware {
         }
         try {
             serverStats.incrementActiveRequestsCount();
-        } catch (Error ex) {
+        } catch (Exception ex) {
             logger.error("Error noting stats for client {}", clientName, ex);
         }            
     }

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/LoadBalancerContext.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/LoadBalancerContext.java
@@ -273,8 +273,8 @@ public class LoadBalancerContext implements IClientConfigAware {
                     stats.clearSuccessiveConnectionFailureCount();
                 }
             }
-        } catch (Throwable ex) {
-            logger.error("Unexpected exception", ex);
+        } catch (Error ex) {
+            logger.error("Error noting stats for client {}", clientName, ex);
         }            
     }
 
@@ -294,8 +294,8 @@ public class LoadBalancerContext implements IClientConfigAware {
                     stats.clearSuccessiveConnectionFailureCount();
                 }
             }
-        } catch (Throwable ex) {
-            logger.error("Unexpected exception", ex);
+        } catch (Error ex) {
+            logger.error("Error noting stats for client {}", clientName, ex);
         }            
     }
 
@@ -310,8 +310,8 @@ public class LoadBalancerContext implements IClientConfigAware {
             if (errorHandler != null && response != null) {
                 stats.clearSuccessiveConnectionFailureCount();
             } 
-        } catch (Throwable ex) {
-            logger.error("Unexpected exception", ex);
+        } catch (Error ex) {
+            logger.error("Error noting stats for client {}", clientName, ex);
         }            
     }
 
@@ -324,9 +324,9 @@ public class LoadBalancerContext implements IClientConfigAware {
         }
         try {
             serverStats.incrementActiveRequestsCount();
-        } catch (Throwable e) {
-            logger.info("Unable to note Server Stats:", e);
-        }
+        } catch (Error ex) {
+            logger.error("Error noting stats for client {}", clientName, ex);
+        }            
     }
 
 

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ResponseTimeWeightedRule.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ResponseTimeWeightedRule.java
@@ -207,7 +207,7 @@ public class ResponseTimeWeightedRule extends RoundRobinRule {
             ServerWeight serverWeight = new ServerWeight();
             try {
                 serverWeight.maintainWeights();
-            } catch (Error e) {
+            } catch (Exception e) {
                 logger.error("Error running DynamicServerWeightTask for {}", name, e);
             }
         }
@@ -253,8 +253,8 @@ public class ResponseTimeWeightedRule extends RoundRobinRule {
                     finalWeights.add(weightSoFar);   
                 }
                 setWeights(finalWeights);
-            } catch (Error t) {
-                logger.error("Error calculating server weights", t);
+            } catch (Exception e) {
+                logger.error("Error calculating server weights", e);
             } finally {
                 serverWeightAssignmentInProgress.set(false);
             }

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ResponseTimeWeightedRule.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ResponseTimeWeightedRule.java
@@ -126,9 +126,7 @@ public class ResponseTimeWeightedRule extends RoundRobinRule {
 
         Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
             public void run() {
-                logger
-                        .info("Stopping NFLoadBalancer-serverWeightTimer-"
-                                + name);
+                logger.info("Stopping NFLoadBalancer-serverWeightTimer-{}", name);
                 serverWeightTimer.cancel();
             }
         }));
@@ -136,7 +134,7 @@ public class ResponseTimeWeightedRule extends RoundRobinRule {
 
     public void shutdown() {
         if (serverWeightTimer != null) {
-            logger.info("Stopping NFLoadBalancer-serverWeightTimer-" + name);
+            logger.info("Stopping NFLoadBalancer-serverWeightTimer-{}", name);
             serverWeightTimer.cancel();
         }
     }
@@ -209,10 +207,8 @@ public class ResponseTimeWeightedRule extends RoundRobinRule {
             ServerWeight serverWeight = new ServerWeight();
             try {
                 serverWeight.maintainWeights();
-            } catch (Throwable t) {
-                logger.error(
-                        "Throwable caught while running DynamicServerWeightTask for "
-                                + name, t);
+            } catch (Error e) {
+                logger.error("Error running DynamicServerWeightTask for {}", name, e);
             }
         }
     }
@@ -257,8 +253,8 @@ public class ResponseTimeWeightedRule extends RoundRobinRule {
                     finalWeights.add(weightSoFar);   
                 }
                 setWeights(finalWeights);
-            } catch (Throwable t) {
-                logger.error("Exception while dynamically calculating server weights", t);
+            } catch (Error t) {
+                logger.error("Error calculating server weights", t);
             } finally {
                 serverWeightAssignmentInProgress.set(false);
             }

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/WeightedResponseTimeRule.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/WeightedResponseTimeRule.java
@@ -222,10 +222,8 @@ public class WeightedResponseTimeRule extends RoundRobinRule {
             ServerWeight serverWeight = new ServerWeight();
             try {
                 serverWeight.maintainWeights();
-            } catch (Throwable t) {
-                logger.error(
-                        "Throwable caught while running DynamicServerWeightTask for "
-                                + name, t);
+            } catch (Error e) {
+                logger.error("Error running DynamicServerWeightTask for {}", name, e);
             }
         }
     }
@@ -270,8 +268,8 @@ public class WeightedResponseTimeRule extends RoundRobinRule {
                     finalWeights.add(weightSoFar);   
                 }
                 setWeights(finalWeights);
-            } catch (Throwable t) {
-                logger.error("Exception while dynamically calculating server weights", t);
+            } catch (Error t) {
+                logger.error("Error calculating server weights", t);
             } finally {
                 serverWeightAssignmentInProgress.set(false);
             }

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/WeightedResponseTimeRule.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/WeightedResponseTimeRule.java
@@ -222,7 +222,7 @@ public class WeightedResponseTimeRule extends RoundRobinRule {
             ServerWeight serverWeight = new ServerWeight();
             try {
                 serverWeight.maintainWeights();
-            } catch (Error e) {
+            } catch (Exception e) {
                 logger.error("Error running DynamicServerWeightTask for {}", name, e);
             }
         }
@@ -268,8 +268,8 @@ public class WeightedResponseTimeRule extends RoundRobinRule {
                     finalWeights.add(weightSoFar);   
                 }
                 setWeights(finalWeights);
-            } catch (Error t) {
-                logger.error("Error calculating server weights", t);
+            } catch (Exception e) {
+                logger.error("Error calculating server weights", e);
             } finally {
                 serverWeightAssignmentInProgress.set(false);
             }

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ZoneAwareLoadBalancer.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ZoneAwareLoadBalancer.java
@@ -136,7 +136,7 @@ public class ZoneAwareLoadBalancer<T extends Server> extends DynamicServerListLo
                     server = zoneLoadBalancer.chooseServer(key);
                 }
             }
-        } catch (Error e) {
+        } catch (Exception e) {
             logger.error("Error choosing server using zone aware logic for load balancer={}", name, e);
         }
         if (server != null) {

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ZoneAwareLoadBalancer.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ZoneAwareLoadBalancer.java
@@ -136,8 +136,8 @@ public class ZoneAwareLoadBalancer<T extends Server> extends DynamicServerListLo
                     server = zoneLoadBalancer.chooseServer(key);
                 }
             }
-        } catch (Throwable e) {
-            logger.error("Unexpected exception when choosing server using zone aware logic", e);
+        } catch (Error e) {
+            logger.error("Error choosing server using zone aware logic for load balancer={}", name, e);
         }
         if (server != null) {
             return server;


### PR DESCRIPTION
- A lot of code was catching and discarding Throwable.  This was masking several bugs and makes it difficult to debug real problems.  
- Improve logging to include the load balancer / client name.  This helps a lot when running many clients in a service.