### PR TITLE
Revert behavioral changes to throwable behavior

### DIFF
--- a/ribbon-loadbalancer/src/main/java/com/netflix/client/ClientFactory.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/client/ClientFactory.java
@@ -72,7 +72,7 @@ public class ClientFactory {
     		if (client instanceof AbstractLoadBalancerAwareClient) {
     			((AbstractLoadBalancerAwareClient) client).setLoadBalancer(loadBalancer);
     		}
-    	} catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+    	} catch (Throwable e) {
     		String message = "Unable to InitializeAndAssociateNFLoadBalancer set for RestClient:"
     				+ restClientName;
     		logger.warn(message, e);
@@ -168,7 +168,7 @@ public class ClientFactory {
             namedLBMap.put(name, lb);            
             logger.info("Client: {} instantiated a LoadBalancer: {}", name, lb);
             return lb;
-        } catch (Exception e) {           
+        } catch (Throwable e) {           
            throw new ClientException("Unable to instantiate/associate LoadBalancer with Client:" + name, e);
         }    	
     }

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/AbstractServerList.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/AbstractServerList.java
@@ -49,7 +49,7 @@ public abstract class AbstractServerList<T extends Server> implements ServerList
             AbstractServerListFilter<T> abstractNIWSServerListFilter = 
                     (AbstractServerListFilter<T>) ClientFactory.instantiateInstanceWithClientConfig(niwsServerListFilterClassName, niwsClientConfig);
             return abstractNIWSServerListFilter;
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+        } catch (Throwable e) {
             throw new ClientException(
                     ClientException.ErrorType.CONFIGURATION,
                     "Unable to get an instance of CommonClientConfigKey.NIWSServerListFilterClassName. Configured class:"

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/BaseLoadBalancer.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/BaseLoadBalancer.java
@@ -735,7 +735,8 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
             try {
                 return rule.choose(key);
             } catch (Exception e) {
-                throw new RuntimeException("Error choosing server for key " + key, e);
+                logger.warn("LoadBalancer [{}]:  Error choosing server for key {}", name, key, e);
+                return null;
             }
         }
     }
@@ -749,7 +750,8 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
                 Server svr = rule.choose(key);
                 return ((svr == null) ? null : svr.getId());
             } catch (Exception e) {
-                throw new RuntimeException("Error choosing server", e);
+                logger.warn("LoadBalancer [{}]:  Error choosing server", name, e);
+                return null;
             }
         }
     }

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/DynamicServerListLoadBalancer.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/DynamicServerListLoadBalancer.java
@@ -250,14 +250,17 @@ public class DynamicServerListLoadBalancer<T extends Server> extends BaseLoadBal
     protected void updateAllServerList(List<T> ls) {
         // other threads might be doing this - in which case, we pass
         if (serverListUpdateInProgress.compareAndSet(false, true)) {
-            for (T s : ls) {
-                s.setAlive(true); // set so that clients can start using these
-                                  // servers right away instead
-                // of having to wait out the ping cycle.
+            try {
+                for (T s : ls) {
+                    s.setAlive(true); // set so that clients can start using these
+                                      // servers right away instead
+                                      // of having to wait out the ping cycle.
+                }
+                setServersList(ls);
+                super.forceQuickPing();
+            } finally {
+                serverListUpdateInProgress.set(false);
             }
-            setServersList(ls);
-            super.forceQuickPing();
-            serverListUpdateInProgress.set(false);
         }
     }
 

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ResponseTimeWeightedRule.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ResponseTimeWeightedRule.java
@@ -90,8 +90,7 @@ public class ResponseTimeWeightedRule extends RoundRobinRule {
 
     protected Timer serverWeightTimer = null;
 
-    protected AtomicBoolean serverWeightAssignmentInProgress = new AtomicBoolean(
-            false);
+    protected AtomicBoolean serverWeightAssignmentInProgress = new AtomicBoolean(false);
 
     String name = "unknown";
 
@@ -220,11 +219,11 @@ public class ResponseTimeWeightedRule extends RoundRobinRule {
             if (lb == null) {
                 return;
             }
-            if (serverWeightAssignmentInProgress.get()) {
-                return; // Ping in progress - nothing to do
-            } else {
-                serverWeightAssignmentInProgress.set(true);
+            
+            if (!serverWeightAssignmentInProgress.compareAndSet(false, true)) {
+                return;
             }
+            
             try {
                 logger.info("Weight adjusting job started");
                 AbstractLoadBalancer nlb = (AbstractLoadBalancer) lb;

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/Server.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/Server.java
@@ -61,7 +61,7 @@ public class Server {
     private String host;
     private int port = 80;
     private volatile String id;
-    private boolean isAliveFlag;
+    private volatile boolean isAliveFlag;
     private String zone = UNKNOWN_ZONE;
     private volatile boolean readyToServe = true;
 

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/WeightedResponseTimeRule.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/WeightedResponseTimeRule.java
@@ -17,18 +17,18 @@
 */
 package com.netflix.loadbalancer;
 
+import com.netflix.client.config.IClientConfig;
+import com.netflix.client.config.IClientConfigKey;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.netflix.client.config.IClientConfig;
-import com.netflix.client.config.IClientConfigKey;
 
 /** 
  * Rule that use the average/percentile response times
@@ -100,8 +100,7 @@ public class WeightedResponseTimeRule extends RoundRobinRule {
 
     protected Timer serverWeightTimer = null;
 
-    protected AtomicBoolean serverWeightAssignmentInProgress = new AtomicBoolean(
-            false);
+    protected AtomicBoolean serverWeightAssignmentInProgress = new AtomicBoolean(false);
 
     String name = "unknown";
 
@@ -235,11 +234,11 @@ public class WeightedResponseTimeRule extends RoundRobinRule {
             if (lb == null) {
                 return;
             }
-            if (serverWeightAssignmentInProgress.get()) {
-                return; // Ping in progress - nothing to do
-            } else {
-                serverWeightAssignmentInProgress.set(true);
+            
+            if (!serverWeightAssignmentInProgress.compareAndSet(false,  true))  {
+                return; 
             }
+            
             try {
                 logger.info("Weight adjusting job started");
                 AbstractLoadBalancer nlb = (AbstractLoadBalancer) lb;


### PR DESCRIPTION
- Revert to previous behavior where Throwable was rethrown as a checked exception.  Continue to rethrow checked exceptions when catching Throwable but still provide a proper stack trace.
- Revert to previous chooseServer behavior that returned null on error.  Still capturing Exception instead of throwable and logging an error
- Fix usage of AtomicBoolean