### PR TITLE
Derived class can override predicate

### DIFF
--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/AvailabilityFilteringRule.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/AvailabilityFilteringRule.java
@@ -83,7 +83,7 @@ public class AvailabilityFilteringRule extends PredicateBasedRule {
         int count = 0;
         Server server = roundRobinRule.choose(key);
         while (count++ <= 10) {
-            if (predicate.apply(new PredicateKey(server))) {
+            if (getPredicate().apply(new PredicateKey(server))) {
                 return server;
             }
             server = roundRobinRule.choose(key);


### PR DESCRIPTION
This pull request is to fix one problem regarding derived class could not override predicate.

The way is to use the corresponding method instead of variable.