### PR TITLE
Support configuring scheme for Server

### DIFF
--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ConfigurationBasedServerList.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ConfigurationBasedServerList.java
@@ -60,7 +60,7 @@ public class ConfigurationBasedServerList extends AbstractServerList<Server>  {
 	    this.clientConfig = clientConfig;
 	}
 	
-	private List<Server> derive(String value) {
+	protected List<Server> derive(String value) {
 	    List<Server> list = Lists.newArrayList();
 		if (!Strings.isNullOrEmpty(value)) {
 			for (String s: value.split(",")) {

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/LoadBalancerContext.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/LoadBalancerContext.java
@@ -571,12 +571,17 @@ public class LoadBalancerContext implements IClientConfigAware {
 
     public URI reconstructURIWithServer(Server server, URI original) {
         String host = server.getHost();
-        int port = server .getPort();
+        int port = server.getPort();
+        String scheme = server.getScheme();
+        
         if (host.equals(original.getHost()) 
-                && port == original.getPort()) {
+                && port == original.getPort()
+                && scheme == original.getScheme()) {
             return original;
         }
-        String scheme = original.getScheme();
+        if (scheme == null) {
+            scheme = original.getScheme();
+        }
         if (scheme == null) {
             scheme = deriveSchemeAndPortFromPartialUri(original).first();
         }

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/Server.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/Server.java
@@ -60,6 +60,7 @@ public class Server {
     public static final String UNKNOWN_ZONE = "UNKNOWN";
     private String host;
     private int port = 80;
+    private String scheme;
     private volatile String id;
     private volatile boolean isAliveFlag;
     private String zone = UNKNOWN_ZONE;
@@ -88,6 +89,14 @@ public class Server {
     };
 
     public Server(String host, int port) {
+        this.host = host;
+        this.port = port;
+        this.id = host + ":" + port;
+        isAliveFlag = false;
+    }
+    
+    public Server(String scheme, String host, int port) {
+        this.scheme = scheme;
         this.host = host;
         this.port = port;
         this.id = host + ":" + port;
@@ -125,6 +134,17 @@ public class Server {
         } else {
             return hostPort.first() + ":" + hostPort.second();
         }
+    }
+    
+    private static String getScheme(String id) {
+        if (id != null) {
+            if (id.toLowerCase().startsWith("http://")) {
+                return "http";
+            } else if (id.toLowerCase().startsWith("https://")) {
+                return "https";
+            }
+        }
+        return null;
     }
 
     static Pair<String, Integer> getHostPort(String id) {
@@ -169,6 +189,7 @@ public class Server {
             this.id = hostPort.first() + ":" + hostPort.second();
             this.host = hostPort.first();
             this.port = hostPort.second();
+            this.scheme = getScheme(id);
         } else {
             this.id = null;
         }
@@ -199,6 +220,10 @@ public class Server {
 
     public int getPort() {
         return port;
+    }
+    
+    public String getScheme() {
+        return scheme;
     }
 
     public String getHostPort() {

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/Server.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/Server.java
@@ -89,10 +89,7 @@ public class Server {
     };
 
     public Server(String host, int port) {
-        this.host = host;
-        this.port = port;
-        this.id = host + ":" + port;
-        isAliveFlag = false;
+        this(null, host, port);
     }
     
     public Server(String scheme, String host, int port) {
@@ -193,6 +190,10 @@ public class Server {
         } else {
             this.id = null;
         }
+    }
+    
+    public void setSchemea(String scheme) {
+        this.scheme = scheme;
     }
 
     public void setPort(int port) {

--- a/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/ServerTest.java
+++ b/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/ServerTest.java
@@ -1,0 +1,65 @@
+package com.netflix.loadbalancer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class ServerTest {
+
+    @Test
+    public void createSchemeHost() {
+        Server server = new Server("http://netflix.com");
+        assertEquals("http", server.getScheme());
+        assertEquals("netflix.com", server.getHost());
+        assertEquals(80, server.getPort());
+    }
+    
+    @Test
+    public void createSchemeHostPort() {
+        Server server = new Server("http://netflix.com:8080");
+        assertEquals("http", server.getScheme());
+        assertEquals("netflix.com", server.getHost());
+        assertEquals(8080, server.getPort());
+    }
+    
+    @Test
+    public void createSecureSchemeHost() {
+        Server server = new Server("https://netflix.com");
+        assertEquals("https", server.getScheme());
+        assertEquals("netflix.com", server.getHost());
+        assertEquals(80, server.getPort());
+    }
+    
+    @Test
+    public void createSecureSchemeHostPort() {
+        Server server = new Server("https://netflix.com:443");
+        assertEquals("https", server.getScheme());
+        assertEquals("netflix.com", server.getHost());
+        assertEquals(443, server.getPort());
+    }
+    
+    @Test
+    public void createSecureSchemeHostPortExplicit() {
+        Server server = new Server("https", "netflix.com", 443);
+        assertEquals("https", server.getScheme());
+        assertEquals("netflix.com", server.getHost());
+        assertEquals(443, server.getPort());
+    }
+    
+    @Test
+    public void createHost() {
+        Server server = new Server("netflix.com");
+        assertNull(server.getScheme());
+        assertEquals("netflix.com", server.getHost());
+        assertEquals(80, server.getPort());
+    }
+    
+    @Test
+    public void createHostPort() {
+        Server server = new Server("netflix.com:8080");
+        assertNull(server.getScheme());
+        assertEquals("netflix.com", server.getHost());
+        assertEquals(8080, server.getPort());
+    }
+}


### PR DESCRIPTION
Support for a `Server` to optionally have a scheme. This allows for a `ServerList` to support instances with different schemes which enables the gradual migration to secure services without a big bang flip over.

Related to #275 which could not be accepted due to concerns about passivity. This change will allow me to extend `ConfigurationBasedServerList` and provide the scheme/port on construction of the `Server` and abstracts the ribbon client IsSecure/SecurePort properties into the individual `Server` instance.

Without this change I will likely be forced to fork ribbon internally, which I would really like to avoid doing. Added a plethora of tests increase the probability of acceptance. 