### PR TITLE
set default https port to 443

### DIFF
--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/Server.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/Server.java
@@ -151,8 +151,10 @@ public class Server {
 
             if (id.toLowerCase().startsWith("http://")) {
                 id = id.substring(7);
+                port = 80;
             } else if (id.toLowerCase().startsWith("https://")) {
                 id = id.substring(8);
+                port = 443;
             }
 
             if (id.contains("/")) {

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/Server.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/Server.java
@@ -166,7 +166,6 @@ public class Server {
 
             if (colon_idx == -1) {
                 host = id; // default
-                port = 80;
             } else {
                 host = id.substring(0, colon_idx);
                 try {

--- a/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/ServerTest.java
+++ b/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/ServerTest.java
@@ -28,7 +28,7 @@ public class ServerTest {
         Server server = new Server("https://netflix.com");
         assertEquals("https", server.getScheme());
         assertEquals("netflix.com", server.getHost());
-        assertEquals(80, server.getPort());
+        assertEquals(443, server.getPort());
     }
     
     @Test


### PR DESCRIPTION
Encountered this issue in feign ribbon client.
In below code snippet, "api.github.com" is reconstructed as **"https://api.github.com:80"** , which cause "java.net.SocketException: Connection reset" error. Default https port should be 443 and the expected URL should be "https://api.github.com:443".
```

final String clientName = "github-client";
getConfigInstance().setProperty(clientName + ".ribbon.listOfServers", "api.github.com");
GitHubClient gitHubClient = Feign.builder()
                .decoder(new GsonDecoder())
                .logLevel(feign.Logger.Level.FULL).logger(new Slf4jLogger())
                .client(RibbonClient.create()).target(GitHubClient.class, "https://" + clientName);
```