### PR TITLE
Check current counter value does not exceed eligible server count

### DIFF
--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/AbstractServerPredicate.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/AbstractServerPredicate.java
@@ -137,9 +137,9 @@ public abstract class AbstractServerPredicate implements Predicate<PredicateKey>
             return results;            
         }
     }
-	
-	/**
-	 * Referenced from RoundRobinRule
+
+    /**
+     * Referenced from RoundRobinRule
      * Inspired by the implementation of {@link AtomicInteger#incrementAndGet()}.
      *
      * @param modulo The modulo to bound the value of the counter.
@@ -149,7 +149,7 @@ public abstract class AbstractServerPredicate implements Predicate<PredicateKey>
         for (;;) {
             int current = nextIndex.get();
             int next = (current + 1) % modulo;
-            if (nextIndex.compareAndSet(current, next))
+            if (nextIndex.compareAndSet(current, next) && current < modulo)
                 return current;
         }
     }


### PR DESCRIPTION
Added check to avoid java.lang.IndexOutOfBoundsException when current counter value becomes greater than eligible server count