### PR TITLE
Extension points for subclassing and some perf optimizations

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ rx_netty_version=0.4.9
 servo_version=0.10.1
 hystrix_version=1.4.3
 guava_version=14.0.1
-archaius_version=0.7.4
+archaius_version=0.7.6
 eureka_version=1.4.6
 jersey_version=1.19.1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ servo_version=0.10.1
 hystrix_version=1.4.3
 guava_version=14.0.1
 archaius_version=0.7.6
-eureka_version=1.4.6
+eureka_version=1.7.2
 jersey_version=1.19.1
 
 junit_version=4.12

--- a/ribbon-core/src/main/java/com/netflix/client/config/CommonClientConfigKey.java
+++ b/ribbon-core/src/main/java/com/netflix/client/config/CommonClientConfigKey.java
@@ -157,6 +157,8 @@ public abstract class CommonClientConfigKey<T> implements IClientConfigKey<T> {
     public static final IClientConfigKey<Integer> NFLoadBalancerPingInterval = new CommonClientConfigKey<Integer>("NFLoadBalancerPingInterval"){};
     
     public static final IClientConfigKey<Integer> NFLoadBalancerMaxTotalPingTime = new CommonClientConfigKey<Integer>("NFLoadBalancerMaxTotalPingTime"){};
+
+    public static final IClientConfigKey<String> NFLoadBalancerStatsClassName = new CommonClientConfigKey<String>("NFLoadBalancerStatsClassName"){};
     
     public static final IClientConfigKey<String> NIWSServerListClassName = new CommonClientConfigKey<String>("NIWSServerListClassName"){};
 

--- a/ribbon-eureka/src/main/java/com/netflix/niws/loadbalancer/DiscoveryEnabledNIWSServerList.java
+++ b/ribbon-eureka/src/main/java/com/netflix/niws/loadbalancer/DiscoveryEnabledNIWSServerList.java
@@ -31,6 +31,7 @@ import com.netflix.discovery.DiscoveryClient;
 import com.netflix.discovery.EurekaClient;
 import com.netflix.loadbalancer.AbstractServerList;
 import com.netflix.loadbalancer.DynamicServerListLoadBalancer;
+import com.netflix.loadbalancer.LoadBalancerStats;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -185,8 +186,7 @@ public class DiscoveryEnabledNIWSServerList extends AbstractServerList<Discovery
                             }
                         }
 
-                        DiscoveryEnabledServer des = new DiscoveryEnabledServer(ii, isSecure, shouldUseIpAddr);
-                        des.setZone(DiscoveryClient.getZone(ii));
+                        DiscoveryEnabledServer des = createServer(ii, isSecure, shouldUseIpAddr);
                         serverList.add(des);
                     }
                 }
@@ -196,6 +196,12 @@ public class DiscoveryEnabledNIWSServerList extends AbstractServerList<Discovery
             }
         }
         return serverList;
+    }
+
+    protected DiscoveryEnabledServer createServer(final InstanceInfo instanceInfo, boolean useSecurePort, boolean useIpAddr) {
+        DiscoveryEnabledServer server = new DiscoveryEnabledServer(instanceInfo, useSecurePort, useIpAddr);
+        server.setZone(DiscoveryClient.getZone(instanceInfo));
+        return server;
     }
 
     public String getVipAddresses() {

--- a/ribbon-eureka/src/main/java/com/netflix/niws/loadbalancer/DiscoveryEnabledNIWSServerList.java
+++ b/ribbon-eureka/src/main/java/com/netflix/niws/loadbalancer/DiscoveryEnabledNIWSServerList.java
@@ -27,11 +27,10 @@ import com.netflix.client.config.DefaultClientConfigImpl;
 import com.netflix.client.config.IClientConfig;
 import com.netflix.client.config.IClientConfigKey.Keys;
 import com.netflix.config.ConfigurationManager;
-import com.netflix.discovery.DiscoveryClient;
 import com.netflix.discovery.EurekaClient;
+import com.netflix.discovery.EurekaClientConfig;
 import com.netflix.loadbalancer.AbstractServerList;
 import com.netflix.loadbalancer.DynamicServerListLoadBalancer;
-import com.netflix.loadbalancer.LoadBalancerStats;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -200,7 +199,13 @@ public class DiscoveryEnabledNIWSServerList extends AbstractServerList<Discovery
 
     protected DiscoveryEnabledServer createServer(final InstanceInfo instanceInfo, boolean useSecurePort, boolean useIpAddr) {
         DiscoveryEnabledServer server = new DiscoveryEnabledServer(instanceInfo, useSecurePort, useIpAddr);
-        server.setZone(DiscoveryClient.getZone(instanceInfo));
+
+        // Get availabilty zone for this instance.
+        EurekaClientConfig clientConfig = eurekaClientProvider.get().getEurekaClientConfig();
+        String[] availZones = clientConfig.getAvailabilityZones(clientConfig.getRegion());
+        String instanceZone = InstanceInfo.getZone(availZones, instanceInfo);
+        server.setZone(instanceZone);
+
         return server;
     }
 

--- a/ribbon-eureka/src/test/java/com/netflix/loadbalancer/EurekaDynamicServerListLoadBalancerTest.java
+++ b/ribbon-eureka/src/test/java/com/netflix/loadbalancer/EurekaDynamicServerListLoadBalancerTest.java
@@ -4,6 +4,7 @@ import com.netflix.appinfo.InstanceInfo;
 import com.netflix.client.config.CommonClientConfigKey;
 import com.netflix.client.config.DefaultClientConfigImpl;
 import com.netflix.discovery.CacheRefreshedEvent;
+import com.netflix.discovery.DefaultEurekaClientConfig;
 import com.netflix.discovery.DiscoveryClient;
 import com.netflix.discovery.EurekaClient;
 import com.netflix.discovery.EurekaEventListener;
@@ -175,6 +176,8 @@ public class EurekaDynamicServerListLoadBalancerTest {
 
     private EurekaClient setUpEurekaClientMock(List<InstanceInfo> servers) {
         final EurekaClient eurekaClientMock = PowerMock.createMock(EurekaClient.class);
+
+        EasyMock.expect(eurekaClientMock.getEurekaClientConfig()).andReturn(new DefaultEurekaClientConfig()).anyTimes();
 
         EasyMock
                 .expect(eurekaClientMock.getInstancesByVipAddress(EasyMock.anyString(), EasyMock.anyBoolean(), EasyMock.anyString()))

--- a/ribbon-eureka/src/test/java/com/netflix/niws/loadbalancer/DiscoveryEnabledLoadBalancerSupportsPortOverrideTest.java
+++ b/ribbon-eureka/src/test/java/com/netflix/niws/loadbalancer/DiscoveryEnabledLoadBalancerSupportsPortOverrideTest.java
@@ -23,7 +23,6 @@ import com.netflix.client.config.DefaultClientConfigImpl;
 import com.netflix.config.ConfigurationManager;
 import com.netflix.discovery.DiscoveryClient;
 import com.netflix.discovery.DiscoveryManager;
-import org.easymock.EasyMock;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -35,7 +34,6 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.easymock.EasyMock.expect;
@@ -69,20 +67,18 @@ public class DiscoveryEnabledLoadBalancerSupportsPortOverrideTest {
     @Before
     public void setupMock(){
 
-        List<InstanceInfo> dummyII = getDummyInstanceInfo("dummy", "http://www.host.com", "1.1.1.1", 8001);
-        List<InstanceInfo> secureDummyII = getDummyInstanceInfo("secureDummy", "http://www.host.com", "1.1.1.1", 8002);
+        List<InstanceInfo> dummyII = LoadBalancerTestUtils.getDummyInstanceInfo("dummy", "http://www.host.com", "1.1.1.1", 8001);
+        List<InstanceInfo> secureDummyII = LoadBalancerTestUtils.getDummyInstanceInfo("secureDummy", "http://www.host.com", "1.1.1.1", 8002);
 
 
         PowerMock.mockStatic(DiscoveryManager.class);
         PowerMock.mockStatic(DiscoveryClient.class);
 
-        DiscoveryClient mockedDiscoveryClient = createMock(DiscoveryClient.class);
+        DiscoveryClient mockedDiscoveryClient = LoadBalancerTestUtils.mockDiscoveryClient();
         DiscoveryManager mockedDiscoveryManager = createMock(DiscoveryManager.class);
 
-        expect(DiscoveryClient.getZone((InstanceInfo) EasyMock.anyObject())).andReturn("dummyZone").anyTimes();
         expect(DiscoveryManager.getInstance()).andReturn(mockedDiscoveryManager).anyTimes();
         expect(mockedDiscoveryManager.getDiscoveryClient()).andReturn(mockedDiscoveryClient).anyTimes();
-
 
         expect(mockedDiscoveryClient.getInstancesByVipAddress("dummy", false, "region")).andReturn(dummyII).anyTimes();
         expect(mockedDiscoveryClient.getInstancesByVipAddress("secureDummy", true, "region")).andReturn(secureDummyII).anyTimes();
@@ -262,23 +258,4 @@ public class DiscoveryEnabledLoadBalancerSupportsPortOverrideTest {
         Assert.assertEquals(8001, serverList2.get(0).getInstanceInfo().getPort());         // client property indicated in ii
         Assert.assertEquals(7002, serverList2.get(0).getInstanceInfo().getSecurePort());   // 7002 is the secure default
     }
-
-
-
-    protected static List<InstanceInfo> getDummyInstanceInfo(String appName, String host, String ipAddr, int port){
-
-        List<InstanceInfo> list = new ArrayList<InstanceInfo>();
-
-        InstanceInfo info = InstanceInfo.Builder.newBuilder().setAppName(appName)
-                .setHostName(host)
-                .setIPAddr(ipAddr)
-                .setPort(port)
-                .build();
-
-        list.add(info);
-
-        return list;
-
-    }
-
 }

--- a/ribbon-eureka/src/test/java/com/netflix/niws/loadbalancer/DiscoveryEnabledLoadBalancerSupportsUseIpAddrTest.java
+++ b/ribbon-eureka/src/test/java/com/netflix/niws/loadbalancer/DiscoveryEnabledLoadBalancerSupportsUseIpAddrTest.java
@@ -25,7 +25,6 @@ import static org.powermock.api.easymock.PowerMock.verify;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -65,21 +64,19 @@ public class DiscoveryEnabledLoadBalancerSupportsUseIpAddrTest {
     @Before
     public void setupMock(){
 
-        List<InstanceInfo> servers = DiscoveryEnabledLoadBalancerSupportsPortOverrideTest.getDummyInstanceInfo("dummy", HOST1, IP1, 8080);
-        List<InstanceInfo> servers2 = DiscoveryEnabledLoadBalancerSupportsPortOverrideTest.getDummyInstanceInfo("dummy", HOST2, IP2, 8080);
+        List<InstanceInfo> servers = LoadBalancerTestUtils.getDummyInstanceInfo("dummy", HOST1, IP1, 8080);
+        List<InstanceInfo> servers2 = LoadBalancerTestUtils.getDummyInstanceInfo("dummy", HOST2, IP2, 8080);
         servers.addAll(servers2);
 
 
         PowerMock.mockStatic(DiscoveryManager.class);
         PowerMock.mockStatic(DiscoveryClient.class);
 
-        DiscoveryClient mockedDiscoveryClient = createMock(DiscoveryClient.class);
+        DiscoveryClient mockedDiscoveryClient = LoadBalancerTestUtils.mockDiscoveryClient();
         DiscoveryManager mockedDiscoveryManager = createMock(DiscoveryManager.class);
 
-        expect(DiscoveryClient.getZone((InstanceInfo) EasyMock.anyObject())).andReturn("dummyZone").anyTimes();
         expect(DiscoveryManager.getInstance()).andReturn(mockedDiscoveryManager).anyTimes();
         expect(mockedDiscoveryManager.getDiscoveryClient()).andReturn(mockedDiscoveryClient).anyTimes();
-
 
         expect(mockedDiscoveryClient.getInstancesByVipAddress("dummy", false, "region")).andReturn(servers).anyTimes();
 

--- a/ribbon-eureka/src/test/java/com/netflix/niws/loadbalancer/LBBuilderTest.java
+++ b/ribbon-eureka/src/test/java/com/netflix/niws/loadbalancer/LBBuilderTest.java
@@ -24,7 +24,6 @@ import com.netflix.loadbalancer.ServerListUpdater;
 import com.netflix.loadbalancer.ZoneAffinityServerListFilter;
 import com.netflix.loadbalancer.ZoneAwareLoadBalancer;
 import org.apache.commons.configuration.Configuration;
-import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,7 +32,6 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.easymock.EasyMock.expect;
@@ -49,16 +47,6 @@ public class LBBuilderTest {
     
     static Server expected = new Server("www.example.com", 8001);
     
-    static List<InstanceInfo> getDummyInstanceInfo(String appName, String host, int port){
-        List<InstanceInfo> list = new ArrayList<InstanceInfo>();
-        InstanceInfo info = InstanceInfo.Builder.newBuilder().setAppName(appName)
-                .setHostName(host)
-                .setPort(port)
-                .build();
-        list.add(info);
-        return list;
-    }
-    
     static class NiwsClientConfig extends DefaultClientConfigImpl {
         public NiwsClientConfig() {
             super();
@@ -72,17 +60,15 @@ public class LBBuilderTest {
     
     @Before
     public void setupMock(){
-        List<InstanceInfo> instances = getDummyInstanceInfo("dummy", expected.getHost(), expected.getPort());
+        List<InstanceInfo> instances = LoadBalancerTestUtils.getDummyInstanceInfo("dummy", expected.getHost(), "127.0.0.1", expected.getPort());
         PowerMock.mockStatic(DiscoveryManager.class);
         PowerMock.mockStatic(DiscoveryClient.class);
 
-        DiscoveryClient mockedDiscoveryClient = createMock(DiscoveryClient.class);
+        DiscoveryClient mockedDiscoveryClient = LoadBalancerTestUtils.mockDiscoveryClient();
         DiscoveryManager mockedDiscoveryManager = createMock(DiscoveryManager.class);
 
-        expect(DiscoveryClient.getZone((InstanceInfo) EasyMock.anyObject())).andReturn("dummyZone").anyTimes();
         expect(DiscoveryManager.getInstance()).andReturn(mockedDiscoveryManager).anyTimes();
         expect(mockedDiscoveryManager.getDiscoveryClient()).andReturn(mockedDiscoveryClient).anyTimes();
-
 
         expect(mockedDiscoveryClient.getInstancesByVipAddress("dummy:7001", false, null)).andReturn(instances).anyTimes();
 

--- a/ribbon-eureka/src/test/java/com/netflix/niws/loadbalancer/LoadBalancerTestUtils.java
+++ b/ribbon-eureka/src/test/java/com/netflix/niws/loadbalancer/LoadBalancerTestUtils.java
@@ -1,0 +1,39 @@
+package com.netflix.niws.loadbalancer;
+
+import com.netflix.appinfo.DataCenterInfo;
+import com.netflix.appinfo.InstanceInfo;
+import com.netflix.appinfo.MyDataCenterInfo;
+import com.netflix.discovery.DefaultEurekaClientConfig;
+import com.netflix.discovery.DiscoveryClient;
+import com.netflix.discovery.DiscoveryManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.easymock.EasyMock.expect;
+import static org.powermock.api.easymock.PowerMock.createMock;
+
+public class LoadBalancerTestUtils
+{
+    static List<InstanceInfo> getDummyInstanceInfo(String appName, String host, String ipAddr, int port){
+        List<InstanceInfo> list = new ArrayList<InstanceInfo>();
+
+        InstanceInfo info = InstanceInfo.Builder.newBuilder().setAppName(appName)
+                .setHostName(host)
+                .setIPAddr(ipAddr)
+                .setPort(port)
+                .setDataCenterInfo(new MyDataCenterInfo(DataCenterInfo.Name.MyOwn))
+                .build();
+
+        list.add(info);
+
+        return list;
+    }
+
+    static DiscoveryClient mockDiscoveryClient()
+    {
+        DiscoveryClient mockedDiscoveryClient = createMock(DiscoveryClient.class);
+        expect(mockedDiscoveryClient.getEurekaClientConfig()).andReturn(new DefaultEurekaClientConfig()).anyTimes();
+        return mockedDiscoveryClient;
+    }
+}

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/BaseLoadBalancer.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/BaseLoadBalancer.java
@@ -160,7 +160,7 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
     }
 
     public BaseLoadBalancer(IClientConfig config, IRule rule, IPing ping) {
-        initWithConfig(config, rule, ping, new LoadBalancerStats((config.getClientName())));
+        initWithConfig(config, rule, ping, createLoadBalancerStatsFromConfig(config));
     }
     
     void initWithConfig(IClientConfig clientConfig, IRule rule, IPing ping, LoadBalancerStats stats) {
@@ -210,9 +210,6 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
                 .getProperty(CommonClientConfigKey.NFLoadBalancerRuleClassName);
         String pingClassName = (String) clientConfig
                 .getProperty(CommonClientConfigKey.NFLoadBalancerPingClassName);
-        String loadBalancerStatsClassName = (String) clientConfig
-                .getProperty(CommonClientConfigKey.NFLoadBalancerStatsClassName, LoadBalancerStats.class.getName());
-
         IRule rule;
         IPing ping;
         LoadBalancerStats stats;
@@ -221,12 +218,22 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
                     ruleClassName, clientConfig);
             ping = (IPing) ClientFactory.instantiateInstanceWithClientConfig(
                     pingClassName, clientConfig);
-            stats = (LoadBalancerStats) ClientFactory.instantiateInstanceWithClientConfig(
-                    loadBalancerStatsClassName, clientConfig);
+            stats = createLoadBalancerStatsFromConfig(clientConfig);
         } catch (Exception e) {
             throw new RuntimeException("Error initializing load balancer", e);
         }
         initWithConfig(clientConfig, rule, ping, stats);
+    }
+
+    private LoadBalancerStats createLoadBalancerStatsFromConfig(IClientConfig clientConfig) {
+        String loadBalancerStatsClassName = clientConfig
+                .get(CommonClientConfigKey.NFLoadBalancerStatsClassName, LoadBalancerStats.class.getName());
+        try {
+            return (LoadBalancerStats) ClientFactory.instantiateInstanceWithClientConfig(
+                    loadBalancerStatsClassName, clientConfig);
+        } catch (Exception e) {
+            throw new RuntimeException("Error initializing LoadBalancerStats", e);
+        }
     }
 
     public void addServerListChangeListener(ServerListChangeListener listener) {

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/BaseLoadBalancer.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/BaseLoadBalancer.java
@@ -162,6 +162,10 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
     public BaseLoadBalancer(IClientConfig config, IRule rule, IPing ping) {
         initWithConfig(config, rule, ping, createLoadBalancerStatsFromConfig(config));
     }
+
+    void initWithConfig(IClientConfig clientConfig, IRule rule, IPing ping) {
+        initWithConfig(clientConfig, rule, ping, createLoadBalancerStatsFromConfig(config));
+    }
     
     void initWithConfig(IClientConfig clientConfig, IRule rule, IPing ping, LoadBalancerStats stats) {
         this.config = clientConfig;
@@ -232,7 +236,9 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
             return (LoadBalancerStats) ClientFactory.instantiateInstanceWithClientConfig(
                     loadBalancerStatsClassName, clientConfig);
         } catch (Exception e) {
-            throw new RuntimeException("Error initializing LoadBalancerStats", e);
+            logger.warn("Error initializing configured LoadBalancerStats class - " + String.valueOf(loadBalancerStatsClassName)
+                    + ". Falling-back to a new LoadBalancerStats instance instead.", e);
+            return new LoadBalancerStats(clientConfig.getClientName());
         }
     }
 

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/LoadBalancerStats.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/LoadBalancerStats.java
@@ -33,6 +33,8 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
+import com.netflix.client.IClientConfigAware;
+import com.netflix.client.config.IClientConfig;
 import com.netflix.config.CachedDynamicIntProperty;
 import com.netflix.config.DynamicIntProperty;
 import com.netflix.config.DynamicPropertyFactory;
@@ -51,7 +53,7 @@ import com.netflix.servo.monitor.Monitors;
  * @author stonse
  * 
  */
-public class LoadBalancerStats {
+public class LoadBalancerStats implements IClientConfigAware {
     
     private static final String PREFIX = "LBStats_";
     
@@ -95,7 +97,7 @@ public class LoadBalancerStats {
         return ss;        
     }
     
-    private LoadBalancerStats(){
+    public LoadBalancerStats(){
         zoneStatsMap = new ConcurrentHashMap<String, ZoneStats>();  
         upServerListZoneMap = new ConcurrentHashMap<String, List<? extends Server>>();        
     }
@@ -105,7 +107,14 @@ public class LoadBalancerStats {
         this.name = name;
         Monitors.registerObject(name, this); 
     }
-       
+
+    @Override
+    public void initWithNiwsConfig(IClientConfig clientConfig)
+    {
+        this.name = clientConfig.getClientName();
+        Monitors.registerObject(name, this);
+    }
+
     public String getName() {
         return name;
     }

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/LoadBalancerStats.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/LoadBalancerStats.java
@@ -33,6 +33,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
+import com.netflix.config.CachedDynamicIntProperty;
 import com.netflix.config.DynamicIntProperty;
 import com.netflix.config.DynamicPropertyFactory;
 import com.netflix.servo.annotations.DataSourceType;
@@ -60,11 +61,11 @@ public class LoadBalancerStats {
     volatile Map<String, ZoneStats> zoneStatsMap = new ConcurrentHashMap<String, ZoneStats>();
     volatile Map<String, List<? extends Server>> upServerListZoneMap = new ConcurrentHashMap<String, List<? extends Server>>();
     
-    private volatile DynamicIntProperty connectionFailureThreshold;
+    private volatile CachedDynamicIntProperty connectionFailureThreshold;
         
-    private volatile DynamicIntProperty circuitTrippedTimeoutFactor;
+    private volatile CachedDynamicIntProperty circuitTrippedTimeoutFactor;
 
-    private volatile DynamicIntProperty maxCircuitTrippedTimeout;
+    private volatile CachedDynamicIntProperty maxCircuitTrippedTimeout;
 
     private static final DynamicIntProperty SERVERSTATS_EXPIRE_MINUTES = 
         DynamicPropertyFactory.getInstance().getIntProperty("niws.loadbalancer.serverStats.expire.minutes", 30);
@@ -113,26 +114,26 @@ public class LoadBalancerStats {
         this.name = name;
     }
 
-    DynamicIntProperty getConnectionFailureCountThreshold() {
+    CachedDynamicIntProperty getConnectionFailureCountThreshold() {
         if (connectionFailureThreshold == null) {
-            connectionFailureThreshold = DynamicPropertyFactory.getInstance().getIntProperty(
+            connectionFailureThreshold = new CachedDynamicIntProperty(
                     "niws.loadbalancer." + name + ".connectionFailureCountThreshold", 3);
         }
         return connectionFailureThreshold;
 
     }
-    
-    DynamicIntProperty getCircuitTrippedTimeoutFactor() {
+
+    CachedDynamicIntProperty getCircuitTrippedTimeoutFactor() {
         if (circuitTrippedTimeoutFactor == null) {
-            circuitTrippedTimeoutFactor = DynamicPropertyFactory.getInstance().getIntProperty(
+            circuitTrippedTimeoutFactor = new CachedDynamicIntProperty(
                     "niws.loadbalancer." + name + ".circuitTripTimeoutFactorSeconds", 10);
         }
         return circuitTrippedTimeoutFactor;        
     }
-    
-    DynamicIntProperty getCircuitTripMaxTimeoutSeconds() {
+
+    CachedDynamicIntProperty getCircuitTripMaxTimeoutSeconds() {
         if (maxCircuitTrippedTimeout == null) {
-            maxCircuitTrippedTimeout = DynamicPropertyFactory.getInstance().getIntProperty(
+            maxCircuitTrippedTimeout = new CachedDynamicIntProperty(
                     "niws.loadbalancer." + name + ".circuitTripMaxTimeoutSeconds", 30);
         }
         return maxCircuitTrippedTimeout;        

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/LoadBalancerStats.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/LoadBalancerStats.java
@@ -86,7 +86,7 @@ public class LoadBalancerStats {
                     }
                 });
         
-    private ServerStats createServerStats(Server server) {
+    protected ServerStats createServerStats(Server server) {
         ServerStats ss = new ServerStats(this);
         //configure custom settings
         ss.setBufferSize(1000);
@@ -171,7 +171,7 @@ public class LoadBalancerStats {
         ss.noteResponseTime(msecs);
     }
     
-    private ServerStats getServerStats(Server server) {
+    protected ServerStats getServerStats(Server server) {
         try {
             return serverStatsCache.get(server);
         } catch (ExecutionException e) {

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/RandomRule.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/RandomRule.java
@@ -17,10 +17,10 @@
  */
 package com.netflix.loadbalancer;
 
-import java.util.List;
-import java.util.Random;
-
 import com.netflix.client.config.IClientConfig;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * A loadbalacing strategy that randomly distributes traffic amongst existing
@@ -30,11 +30,6 @@ import com.netflix.client.config.IClientConfig;
  * 
  */
 public class RandomRule extends AbstractLoadBalancerRule {
-    Random rand;
-
-    public RandomRule() {
-        rand = new Random();
-    }
 
     /**
      * Randomly choose from all living servers
@@ -62,7 +57,7 @@ public class RandomRule extends AbstractLoadBalancerRule {
                 return null;
             }
 
-            int index = rand.nextInt(serverCount);
+            int index = chooseRandomInt(serverCount);
             server = upList.get(index);
 
             if (server == null) {
@@ -86,6 +81,10 @@ public class RandomRule extends AbstractLoadBalancerRule {
 
         return server;
 
+    }
+
+    protected int chooseRandomInt(int serverCount) {
+        return ThreadLocalRandom.current().nextInt(serverCount);
     }
 
 	@Override

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ServerStats.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ServerStats.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.netflix.config.CachedDynamicIntProperty;
 import com.netflix.config.DynamicIntProperty;
 import com.netflix.config.DynamicPropertyFactory;
 import com.netflix.servo.annotations.DataSourceType;
@@ -41,9 +42,9 @@ public class ServerStats {
     
     private static final int DEFAULT_PUBLISH_INTERVAL =  60 * 1000; // = 1 minute
     private static final int DEFAULT_BUFFER_SIZE = 60 * 1000; // = 1000 requests/sec for 1 minute
-    private final DynamicIntProperty connectionFailureThreshold;    
-    private final DynamicIntProperty circuitTrippedTimeoutFactor; 
-    private final DynamicIntProperty maxCircuitTrippedTimeout;
+    private final CachedDynamicIntProperty connectionFailureThreshold;
+    private final CachedDynamicIntProperty circuitTrippedTimeoutFactor;
+    private final CachedDynamicIntProperty maxCircuitTrippedTimeout;
     private static final DynamicIntProperty activeRequestsCountTimeout = 
         DynamicPropertyFactory.getInstance().getIntProperty("niws.loadbalancer.serverStats.activeRequestsCount.effectiveWindowSeconds", 60 * 10);
     
@@ -82,12 +83,12 @@ public class ServerStats {
     private volatile long firstConnectionTimestamp = 0;
     
     public ServerStats() {
-        connectionFailureThreshold = DynamicPropertyFactory.getInstance().getIntProperty(
+        connectionFailureThreshold = new CachedDynamicIntProperty(
                 "niws.loadbalancer.default.connectionFailureCountThreshold", 3);        
-        circuitTrippedTimeoutFactor = DynamicPropertyFactory.getInstance().getIntProperty(
+        circuitTrippedTimeoutFactor = new CachedDynamicIntProperty(
                 "niws.loadbalancer.default.circuitTripTimeoutFactorSeconds", 10);
 
-        maxCircuitTrippedTimeout = DynamicPropertyFactory.getInstance().getIntProperty(
+        maxCircuitTrippedTimeout = new CachedDynamicIntProperty(
                 "niws.loadbalancer.default.circuitTripMaxTimeoutSeconds", 30);
     }
     
@@ -114,6 +115,10 @@ public class ServerStats {
     public void close() {
         if (publisher != null)
             publisher.stop();
+    }
+
+    public Server getServer() {
+        return server;
     }
 
     private int getBufferSize() {

--- a/ribbon-test/build.gradle
+++ b/ribbon-test/build.gradle
@@ -3,7 +3,7 @@ dependencies {
     compile project(':ribbon-loadbalancer')
     compile project(':ribbon-eureka')
     compile 'org.codehaus.jackson:jackson-mapper-asl:1.9.11'
-    compile 'com.netflix.eureka:eureka-client:1.1.142'
+    compile "com.netflix.eureka:eureka-client:${eureka_version}"
     compile "io.reactivex:rxjava:${rx_java_version}"
     compile 'javax.ws.rs:jsr311-api:1.1.1'  
     compile "com.google.guava:guava:${guava_version}"

--- a/ribbon-test/src/main/java/com/netflix/ribbon/testutils/MockedDiscoveryServerListTest.java
+++ b/ribbon-test/src/main/java/com/netflix/ribbon/testutils/MockedDiscoveryServerListTest.java
@@ -15,7 +15,10 @@
  */
 package com.netflix.ribbon.testutils;
 
+import com.netflix.appinfo.DataCenterInfo;
 import com.netflix.appinfo.InstanceInfo;
+import com.netflix.appinfo.MyDataCenterInfo;
+import com.netflix.discovery.DefaultEurekaClientConfig;
 import com.netflix.discovery.DiscoveryClient;
 import com.netflix.discovery.DiscoveryManager;
 import com.netflix.loadbalancer.Server;
@@ -53,6 +56,7 @@ public abstract class MockedDiscoveryServerListTest {
             InstanceInfo info = InstanceInfo.Builder.newBuilder().setAppName(appName)
                     .setHostName(server.getHost())
                     .setPort(server.getPort())
+                    .setDataCenterInfo(new MyDataCenterInfo(DataCenterInfo.Name.MyOwn))
                     .build();
             list.add(info);
         }
@@ -68,7 +72,7 @@ public abstract class MockedDiscoveryServerListTest {
         DiscoveryClient mockedDiscoveryClient = createMock(DiscoveryClient.class);
         DiscoveryManager mockedDiscoveryManager = createMock(DiscoveryManager.class);
 
-        expect(DiscoveryClient.getZone((InstanceInfo) EasyMock.anyObject())).andReturn("dummyZone").anyTimes();
+        expect(mockedDiscoveryClient.getEurekaClientConfig()).andReturn(new DefaultEurekaClientConfig()).anyTimes();
         expect(DiscoveryManager.getInstance()).andReturn(mockedDiscoveryManager).anyTimes();
         expect(mockedDiscoveryManager.getDiscoveryClient()).andReturn(mockedDiscoveryClient).anyTimes();
 


### PR DESCRIPTION
I've been experimenting with some different load-balancing mechanisms, and had to initially copy-paste some of the ribbon code to allow overriding and extending. Now thats complete, I'd like to get these changes pushed down into ribbon so that I can remove the duplication.

As part of the experimenting, load-testing and profiling, a couple of hotspots came up around the use of `DynamicIntProperty` and `java.util.Random`, so I'm submitting those small changes too.

Extension points:
* Allow the `LoadBalancerStats` implementation to be chosen using a new `ClientConfigKey` in `BaseLoadBalancer`.
* Change some methods in `LoadBalancerStats` from private to protected so they can be overridden in subclasses.
* Allow subclasses of `DiscoveryEnabledNIWSServerList` to override the type of `DiscoveryEnabledServer` instances created by adding a protected `createServer()` method.

Optimizations:
* Change `RandomRule` to use a `ThreadLocalRandom` instead of `Random`, as a perf optimization.
* Change `ServerStats` and `LoadBalancerStats` to use `CachedDynamicIntProperty` instead of `DynamicIntProperty` as a perf optimization.
