### PR TITLE
RandomRule policy modification

### DIFF
--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/RandomRule.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/RandomRule.java
@@ -48,17 +48,18 @@ public class RandomRule extends AbstractLoadBalancerRule {
             List<Server> upList = lb.getReachableServers();
             List<Server> allList = lb.getAllServers();
 
+            int upCount = upList.size();
             int serverCount = allList.size();
-            if (serverCount == 0) {
+            if (serverCount == 0 || upCount == 0) {
                 /*
-                 * No servers. End regardless of pass, because subsequent passes
+                 * No servers or No servers available. End regardless of pass, because subsequent passes
                  * only get more restrictive.
                  */
                 return null;
             }
 
             int index = chooseRandomInt(serverCount);
-            server = upList.get(index);
+            server = allList.get(index);
 
             if (server == null) {
                 /*


### PR DESCRIPTION
In the RandomRule's choose method, it use upList to get server, the index of the server come from "ThreadLocalRandom.current().nextInt(serverCount)", so the serverCount is the number of all server. But to get the rechable server is to use upList like this: 
![image](https://user-images.githubusercontent.com/24506830/49488360-48c2dd80-f881-11e8-882f-5d5c3d637601.png)
It seems to happen that the index(come from index = ThreadLocalRandom.current().nextInt(serverCount) ) is larger than the upList's size.