### PR TITLE
configuration: Decouple static archaius

### DIFF
--- a/ribbon-archaius/src/main/java/com/netflix/client/config/ArchaiusDynamicPropertyRepository.java
+++ b/ribbon-archaius/src/main/java/com/netflix/client/config/ArchaiusDynamicPropertyRepository.java
@@ -1,0 +1,119 @@
+package com.netflix.client.config;
+
+import com.google.common.base.Preconditions;
+import com.netflix.config.ConfigurationManager;
+import com.netflix.config.DynamicPropertyFactory;
+import com.netflix.config.PropertyWrapper;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.SubsetConfiguration;
+
+import java.lang.reflect.Type;
+import java.util.function.Consumer;
+
+public final class ArchaiusDynamicPropertyRepository implements DynamicPropertyRepository {
+    private final Configuration config;
+
+    public ArchaiusDynamicPropertyRepository() {
+        this(ConfigurationManager.getConfigInstance());
+    }
+
+    public ArchaiusDynamicPropertyRepository(Configuration config) {
+        this.config = config;
+    }
+
+    @Override
+    public int getPriority() {
+        return 0;
+    }
+
+    private <T> PropertyWrapper<T> getPropertyWrapper(String propName, Class<T> type, T defaultValue) {
+        Preconditions.checkArgument(propName != null, "propName may not be null");
+        Preconditions.checkArgument(type != null, "type may not be null");
+
+        try {
+            if (String.class.equals(type)) {
+                return (PropertyWrapper<T>) DynamicPropertyFactory.getInstance().getStringProperty(propName, (String) defaultValue);
+            } else if (Integer.class.equals(type)) {
+                return (PropertyWrapper<T>) DynamicPropertyFactory.getInstance().getIntProperty(propName, (Integer) defaultValue);
+            } else if (Boolean.class.equals(type)) {
+                return (PropertyWrapper<T>) DynamicPropertyFactory.getInstance().getBooleanProperty(propName, (Boolean) defaultValue);
+            } else if (Double.class.equals(type)) {
+                return (PropertyWrapper<T>) DynamicPropertyFactory.getInstance().getDoubleProperty(propName, (Double) defaultValue);
+            } else if (Float.class.equals(type)) {
+                return (PropertyWrapper<T>) DynamicPropertyFactory.getInstance().getFloatProperty(propName, (Float) defaultValue);
+            } else if (Long.class.equals(type)) {
+                return (PropertyWrapper<T>) DynamicPropertyFactory.getInstance().getLongProperty(propName, (Long) defaultValue);
+            } else {
+                throw new UnsupportedOperationException("Dynamic properties for " + type + " not supported");
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(String.format("Error getting property '%s'", propName), e);
+        }
+    }
+    @Override
+    public <T> DynamicProperty<T> getTypedProperty(String key, Type type, T defaultValue) {
+        final String propName;
+        if (config instanceof SubsetConfiguration) {
+            SubsetConfiguration subset = (SubsetConfiguration)config;
+            propName = subset.getPrefix() + "." + key;
+        } else {
+            propName = key;
+        }
+
+        final PropertyWrapper<T> propertyWrapper = getPropertyWrapper(propName, (Class)type, defaultValue);
+
+        return new DynamicProperty<T>() {
+            @Override
+            public void onChange(Consumer<T> consumer) {
+                Runnable callback = new Runnable() {
+                    @Override
+                    public void run() {
+                        consumer.accept(propertyWrapper.getValue());
+                    }
+
+                    // equals and hashcode needed
+                    // since this is anonymous object is later used as a set key
+
+                    @Override
+                    public boolean equals(Object other){
+                        if (other == null) {
+                            return false;
+                        }
+                        if (getClass() == other.getClass()) {
+                            return toString().equals(other.toString());
+                        }
+                        return false;
+                    }
+
+                    @Override
+                    public String toString(){
+                        return propName;
+                    }
+
+                    @Override
+                    public int hashCode(){
+                        return propName.hashCode();
+                    }
+                };
+
+                propertyWrapper.addCallback(callback);
+            }
+
+            @Override
+            public T get() {
+                return propertyWrapper.getValue();
+            }
+        };
+    }
+
+    @Override
+    public ArchaiusDynamicPropertyRepository withPrefix(String prefix) {
+        return new ArchaiusDynamicPropertyRepository(config.subset(prefix));
+    }
+
+    @Override
+    public void forEachPropertyName(Consumer<String> consumer) {
+        config.getKeys().forEachRemaining(consumer);
+    }
+
+}

--- a/ribbon-archaius/src/main/resources/META-INF/services/com.netflix.client.config.DynamicPropertyRepository
+++ b/ribbon-archaius/src/main/resources/META-INF/services/com.netflix.client.config.DynamicPropertyRepository
@@ -1,0 +1,1 @@
+com.netflix.client.config.ArchaiusDynamicPropertyRepository

--- a/ribbon-core/src/main/java/com/netflix/client/config/ClientConfigFactory.java
+++ b/ribbon-core/src/main/java/com/netflix/client/config/ClientConfigFactory.java
@@ -36,8 +36,6 @@ public interface ClientConfigFactory {
                         .comparingInt(ClientConfigFactory::getPriority)
                         .thenComparing(Comparator.comparing(f -> f.getClass().getCanonicalName())))
                 .findFirst()
-                .orElseGet(() -> {
-                    throw new IllegalStateException("Expecting at least one implementation of ClientConfigFactory discoverable via the ServiceLoader");
-                });
+                .orElse(null);
     }
 }

--- a/ribbon-core/src/main/java/com/netflix/client/config/DynamicProperty.java
+++ b/ribbon-core/src/main/java/com/netflix/client/config/DynamicProperty.java
@@ -1,0 +1,20 @@
+package com.netflix.client.config;
+
+import java.util.function.Consumer;
+
+/**
+ * Ribbon specific constract to abstract from dynamic configuration sources
+ * @param <T>
+ */
+public interface DynamicProperty<T> {
+    /**
+     * Register a consumer to be called when the configuration changes
+     * @param consumer
+     */
+    void onChange(Consumer<T> consumer);
+
+    /**
+     * @return Get the current value or default value
+     */
+    T get();
+}

--- a/ribbon-core/src/main/java/com/netflix/client/config/DynamicPropertyRepository.java
+++ b/ribbon-core/src/main/java/com/netflix/client/config/DynamicPropertyRepository.java
@@ -1,0 +1,61 @@
+package com.netflix.client.config;
+
+import java.lang.reflect.Type;
+import java.util.Comparator;
+import java.util.ServiceLoader;
+import java.util.function.Consumer;
+import java.util.stream.StreamSupport;
+
+/**
+ * Ribbon specific abstraction to a Repository of dynamic configuration properties
+ */
+public interface DynamicPropertyRepository {
+    DynamicPropertyRepository DEFAULT = findDynamicPropertyRepository();
+
+    /**
+     * Proprity of the repository when loading from the server loader.  The highest priority wins
+     * @return
+     */
+    int getPriority();
+
+    /**
+     * Look for a static DynamicPropertyRepository via the service loader.  It's OK to have an empty repository for
+     * situations where one is provided via dependency injection.
+     * @return
+     */
+    static DynamicPropertyRepository findDynamicPropertyRepository() {
+        return StreamSupport.stream(ServiceLoader.load(DynamicPropertyRepository.class).spliterator(), false)
+                .sorted(Comparator
+                        .comparingInt(DynamicPropertyRepository::getPriority)
+                        .thenComparing(Comparator.comparing(f -> f.getClass().getCanonicalName())))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Return a DynamicProperty for the names key and type.  Will return the specified default value if not found.
+     * @param key
+     * @param type
+     * @param defaultValue
+     * @param <T>
+     * @return
+     */
+    default <T> DynamicProperty<T> getProperty(String key, Class<T> type, T defaultValue) {
+        return getTypedProperty(key, type, defaultValue);
+    }
+
+    <T> DynamicProperty<T> getTypedProperty(String key, Type type, T defaultValue);
+
+    /**
+     * Return a new {@link DynamicPropertyRepository} containing only properties with the specified prefix
+     * @param prefix
+     * @return
+     */
+    DynamicPropertyRepository withPrefix(String prefix);
+
+    /**
+     * Invoked the provided consumer for every property name
+     * @param consumer
+     */
+    void forEachPropertyName(Consumer<String> consumer);
+}

--- a/ribbon-core/src/main/java/com/netflix/client/config/IClientConfig.java
+++ b/ribbon-core/src/main/java/com/netflix/client/config/IClientConfig.java
@@ -109,6 +109,10 @@ public interface IClientConfig {
         return get(key, key.getDefaultValue());
     }
 
+    default DynamicPropertyRepository getDynamicPropertyRepository() {
+        return DynamicPropertyRepository.DEFAULT;
+    }
+
     /**
      * Returns a typed property. If the property of IClientConfigKey is not set, 
      * it returns the default value passed in as the parameter.

--- a/ribbon-core/src/main/java/com/netflix/client/config/UnboxedIntProperty.java
+++ b/ribbon-core/src/main/java/com/netflix/client/config/UnboxedIntProperty.java
@@ -1,0 +1,15 @@
+package com.netflix.client.config;
+
+public class UnboxedIntProperty {
+    private volatile int value;
+
+    public UnboxedIntProperty(DynamicProperty<Integer> delegate) {
+        this.value = delegate.get();
+
+        delegate.onChange(newValue -> this.value = newValue);
+    }
+
+    public int get() {
+        return value;
+    }
+}

--- a/ribbon-eureka/build.gradle
+++ b/ribbon-eureka/build.gradle
@@ -1,10 +1,10 @@
 dependencies {
     compile project(':ribbon-core')
     compile project(':ribbon-loadbalancer')
+    compile project(':ribbon-archaius')
     compile "com.netflix.eureka:eureka-client:${eureka_version}"
     compile 'com.google.code.findbugs:annotations:2.0.0'
     compile 'org.slf4j:slf4j-api:1.6.4'
-    compile "com.netflix.archaius:archaius-core:${archaius_version}"
 
     testCompile project(":ribbon-archaius")
     testCompile "junit:junit:${junit_version}"

--- a/ribbon-eureka/src/test/java/com/netflix/niws/loadbalancer/DefaultNIWSServerListFilterTest.java
+++ b/ribbon-eureka/src/test/java/com/netflix/niws/loadbalancer/DefaultNIWSServerListFilterTest.java
@@ -40,7 +40,7 @@ import com.netflix.loadbalancer.ZoneAffinityServerListFilter;
 public class DefaultNIWSServerListFilterTest {
     @BeforeClass
     public static void init() {
-    	ConfigurationManager.getDeploymentContext().setValue(ContextKey.zone, "us-eAst-1C");
+    	ConfigurationManager.getConfigInstance().setProperty(ContextKey.zone.getKey(), "us-eAst-1C");
     }
     
     private DiscoveryEnabledServer createServer(String host, String zone) {

--- a/ribbon-httpclient/build.gradle
+++ b/ribbon-httpclient/build.gradle
@@ -10,7 +10,6 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.6.4'
     compile "com.netflix.servo:servo-core:${servo_version}"
     compile "com.google.guava:guava:${guava_version}"
-    compile "com.netflix.archaius:archaius-core:${archaius_version}"
     compile 'com.netflix.netflix-commons:netflix-commons-util:0.1.1'
     testCompile 'junit:junit:4.11'
     testCompile 'org.slf4j:slf4j-log4j12:1.7.2'

--- a/ribbon-loadbalancer/build.gradle
+++ b/ribbon-loadbalancer/build.gradle
@@ -5,7 +5,6 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.6.4'
     compile "com.netflix.servo:servo-core:${servo_version}"
     compile "com.google.guava:guava:${guava_version}"
-    compile "com.netflix.archaius:archaius-core:${archaius_version}"
     compile 'com.netflix.netflix-commons:netflix-commons-util:0.1.1'
 
     testCompile project(":ribbon-archaius")

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/AbstractServerPredicate.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/AbstractServerPredicate.java
@@ -28,6 +28,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.netflix.client.config.DynamicPropertyRepository;
 import com.netflix.client.config.IClientConfig;
 import com.netflix.loadbalancer.PredicateKey;
 
@@ -48,7 +49,7 @@ public abstract class AbstractServerPredicate implements Predicate<PredicateKey>
     private final Random random = new Random();
     
     private final AtomicInteger nextIndex = new AtomicInteger();
-            
+
     private final Predicate<Server> serverOnlyPredicate =  new Predicate<Server>() {
         @Override
         public boolean apply(@Nullable Server input) {                    
@@ -56,7 +57,7 @@ public abstract class AbstractServerPredicate implements Predicate<PredicateKey>
         }
     };
 
-    public static AbstractServerPredicate alwaysTrue() { 
+    public static AbstractServerPredicate alwaysTrue() {
         return new AbstractServerPredicate() {        
             @Override
             public boolean apply(@Nullable PredicateKey input) {
@@ -72,15 +73,21 @@ public abstract class AbstractServerPredicate implements Predicate<PredicateKey>
     public AbstractServerPredicate(IRule rule) {
         this.rule = rule;
     }
-    
+
+    @Deprecated
     public AbstractServerPredicate(IRule rule, IClientConfig clientConfig) {
-        this.rule = rule;
+        this(rule);
     }
-    
+
+    @Deprecated
     public AbstractServerPredicate(LoadBalancerStats lbStats, IClientConfig clientConfig) {
+        this(lbStats);
+    }
+
+    public AbstractServerPredicate(LoadBalancerStats lbStats) {
         this.lbStats = lbStats;
     }
-    
+
     protected LoadBalancerStats getLBStats() {
         if (lbStats != null) {
             return lbStats;

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/AvailabilityFilteringRule.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/AvailabilityFilteringRule.java
@@ -49,9 +49,7 @@ public class AvailabilityFilteringRule extends PredicateBasedRule {
     
     public AvailabilityFilteringRule() {
     	super();
-    	predicate = CompositePredicate.withPredicate(new AvailabilityPredicate(this, null))
-                .addFallbackPredicate(AbstractServerPredicate.alwaysTrue())
-                .build();
+        initWithNiwsConfig(null);
     }
     
     

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/AvailabilityPredicate.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/AvailabilityPredicate.java
@@ -17,13 +17,11 @@
  */
 package com.netflix.loadbalancer;
 
-import javax.annotation.Nullable;
-
+import com.netflix.client.config.DynamicProperty;
+import com.netflix.client.config.DynamicPropertyRepository;
 import com.netflix.client.config.IClientConfig;
-import com.netflix.config.ChainedDynamicProperty;
-import com.netflix.config.DynamicBooleanProperty;
-import com.netflix.config.DynamicIntProperty;
-import com.netflix.config.DynamicPropertyFactory;
+
+import javax.annotation.Nullable;
 
 /**
  * Predicate with the logic of filtering out circuit breaker tripped servers and servers 
@@ -34,36 +32,55 @@ import com.netflix.config.DynamicPropertyFactory;
  */
 public class AvailabilityPredicate extends  AbstractServerPredicate {
         
-    private static final DynamicBooleanProperty CIRCUIT_BREAKER_FILTERING =
-            DynamicPropertyFactory.getInstance().getBooleanProperty("niws.loadbalancer.availabilityFilteringRule.filterCircuitTripped", true);
+    private DynamicProperty<Boolean> circuitBreakerFiltering;
+    private DynamicProperty<Integer> defaultActiveConnectionsLimit;
+    private DynamicProperty<Integer> activeConnectionsLimit;
 
-    private static final DynamicIntProperty ACTIVE_CONNECTIONS_LIMIT =
-            DynamicPropertyFactory.getInstance().getIntProperty("niws.loadbalancer.availabilityFilteringRule.activeConnectionsLimit", Integer.MAX_VALUE);
+    private final DynamicPropertyRepository repository;
 
-    private ChainedDynamicProperty.IntProperty activeConnectionsLimit = new ChainedDynamicProperty.IntProperty(ACTIVE_CONNECTIONS_LIMIT);
-        
     public AvailabilityPredicate(IRule rule, IClientConfig clientConfig) {
-        super(rule, clientConfig);
+        super(rule);
+        this.repository = clientConfig == null ? DynamicPropertyRepository.DEFAULT : clientConfig.getDynamicPropertyRepository();
         initDynamicProperty(clientConfig);
     }
-    
+
     public AvailabilityPredicate(LoadBalancerStats lbStats, IClientConfig clientConfig) {
-        super(lbStats, clientConfig);
+        super(lbStats);
+        this.repository = clientConfig == null ? DynamicPropertyRepository.DEFAULT :  clientConfig.getDynamicPropertyRepository();
         initDynamicProperty(clientConfig);
     }
-    
+
     AvailabilityPredicate(IRule rule) {
         super(rule);
+        this.repository = DynamicPropertyRepository.DEFAULT;
+        initDynamicProperty(null);
     }
 
     private void initDynamicProperty(IClientConfig clientConfig) {
-        String id = "default";
+        this.circuitBreakerFiltering = repository.getProperty("niws.loadbalancer.availabilityFilteringRule.filterCircuitTripped", Boolean.class, true);
+        this.defaultActiveConnectionsLimit = repository.getProperty("niws.loadbalancer.availabilityFilteringRule.activeConnectionsLimit", Integer.class, Integer.MAX_VALUE);
+
         if (clientConfig != null) {
-            id = clientConfig.getClientName();
-            activeConnectionsLimit = new ChainedDynamicProperty.IntProperty(id + "." + clientConfig.getNameSpace() + ".ActiveConnectionsLimit", ACTIVE_CONNECTIONS_LIMIT); 
-        }               
+            activeConnectionsLimit = repository.getProperty(
+                    clientConfig.getClientName() + "." + clientConfig.getNameSpace() + ".ActiveConnectionsLimit",
+                    Integer.class,
+                    Integer.MAX_VALUE);
+        } else {
+            activeConnectionsLimit = defaultActiveConnectionsLimit;
+        }
     }
-    
+
+    private int getActiveConnectionsLimit() {
+        Integer limit = activeConnectionsLimit.get();
+        if (limit == null) {
+            limit = defaultActiveConnectionsLimit.get();
+            if (limit == null) {
+                limit = Integer.MAX_VALUE;
+            }
+        }
+        return limit;
+    }
+
     @Override
     public boolean apply(@Nullable PredicateKey input) {
         LoadBalancerStats stats = getLBStats();
@@ -73,10 +90,9 @@ public class AvailabilityPredicate extends  AbstractServerPredicate {
         return !shouldSkipServer(stats.getSingleServerStat(input.getServer()));
     }
     
-    
-    private boolean shouldSkipServer(ServerStats stats) {        
-        if ((CIRCUIT_BREAKER_FILTERING.get() && stats.isCircuitBreakerTripped()) 
-                || stats.getActiveRequestsCount() >= activeConnectionsLimit.get()) {
+    private boolean shouldSkipServer(ServerStats stats) {
+        if ((circuitBreakerFiltering.get() && stats.isCircuitBreakerTripped())
+                || stats.getActiveRequestsCount() >= getActiveConnectionsLimit()) {
             return true;
         }
         return false;

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ZoneAffinityPredicate.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ZoneAffinityPredicate.java
@@ -17,28 +17,26 @@
  */
 package com.netflix.loadbalancer;
 
-import com.netflix.config.ConfigurationManager;
-import com.netflix.config.DeploymentContext.ContextKey;
-import com.netflix.loadbalancer.AbstractServerPredicate;
-import com.netflix.loadbalancer.PredicateKey;
-import com.netflix.loadbalancer.Server;
+import com.netflix.client.config.DynamicPropertyRepository;
 
 /**
  * A predicate the filters out servers that are not in the same zone as the client's current
- * zone. The current zone is determined from the call
- * 
- * <pre>{@code
- * ConfigurationManager.getDeploymentContext().getValue(ContextKey.zone);
- * }</pre>
+ * zone.
  * 
  * @author awang
  *
  */
 public class ZoneAffinityPredicate extends AbstractServerPredicate {
 
-    private final String zone = ConfigurationManager.getDeploymentContext().getValue(ContextKey.zone);
-    
-    public ZoneAffinityPredicate() {        
+    private final String zone;
+
+    @Deprecated
+    public ZoneAffinityPredicate() {
+        this(DynamicPropertyRepository.DEFAULT.getProperty("@zone", String.class, (String)null).get());
+    }
+
+    public ZoneAffinityPredicate(String zone) {
+        this.zone = zone;
     }
 
     @Override

--- a/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/PredicatesTest.java
+++ b/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/PredicatesTest.java
@@ -168,9 +168,11 @@ public class PredicatesTest {
         assertTrue(predicate.apply(new PredicateKey((Server) stats[0][0])));
         assertTrue(predicate.apply(new PredicateKey((Server) stats[9][0])));
     }
-    
+
     @Test
     public void testCompositePredicate() {
+        ConfigurationManager.getConfigInstance().setProperty(ContextKey.zone.getKey(), "0");
+
         Object[][] stats = new Object[10][3];
         Map<String, List<Server>> zoneMap = Maps.newHashMap();
         List<Server> expectedFiltered = Lists.newArrayList();
@@ -205,7 +207,7 @@ public class PredicatesTest {
         LoadBalancerStats lbStats = new LoadBalancerStats("default");
         setServerStats(lbStats, stats);
         lbStats.updateZoneServerMapping(zoneMap);
-        ConfigurationManager.getDeploymentContext().setValue(ContextKey.zone, "0");
+
         AvailabilityPredicate p1 = new AvailabilityPredicate(lbStats, null);
         ZoneAffinityPredicate p2 = new ZoneAffinityPredicate();
         CompositePredicate c = CompositePredicate.withPredicates(p2, p1).build();

--- a/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/SubsetFilterTest.java
+++ b/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/SubsetFilterTest.java
@@ -44,8 +44,7 @@ public class SubsetFilterTest {
         config.setProperty(
                 DefaultClientConfigImpl.DEFAULT_PROPERTY_NAME_SPACE + ".ServerListSubsetFilter.size", "5");
         
-        config.setProperty("SubsetFilerTest.ribbon.NFLoadBalancerClassName", 
-                com.netflix.loadbalancer.DynamicServerListLoadBalancer.class.getName());
+        config.setProperty("SubsetFilerTest.ribbon.NFLoadBalancerClassName", com.netflix.loadbalancer.DynamicServerListLoadBalancer.class.getName());
         config.setProperty("SubsetFilerTest.ribbon.NIWSServerListClassName", MockServerList.class.getName());
         config.setProperty("SubsetFilerTest.ribbon.NIWSServerListFilterClassName", ServerListSubsetFilter.class.getName());
         // turn off auto refresh


### PR DESCRIPTION
**Motivation**
Ribbon makes heavy use of Archaius in a static manner for configuration.  This pattern couple Ribbon with legacy archaius and its dependencies and makes it hard to run tests in parallel. By decoupling from both archaius and statics users can now provide alternative configuration mechanisms as well as improve testability.

**Changes**
- Introduce a new DynamicPropertyRepository abstraction to decouple from Archaius specific APIs
- For legacy support make the ArchaiusDynamicPropertyRepository discoverable via the service loader.
- Allow a non-static DynamicPropertyRepository to be associated with a IClientConfig.  This is a bit of a hack but minimizes code changes.
- Decouple all build.gradle dependencies from archaius, except for the ribbon-archaius subproject
- Pick up @zone from DynamicPropertyRepository and NOT from archaius's DeploymentContext
- Remove configuration for PollingServerListUpdater as it is not used and would always require static configuration