### PR TITLE
Deprecate config apis

### DIFF
--- a/ribbon-archaius/src/main/java/com/netflix/client/config/DefaultClientConfigImpl.java
+++ b/ribbon-archaius/src/main/java/com/netflix/client/config/DefaultClientConfigImpl.java
@@ -85,54 +85,79 @@ myclient.foo.ReadTimeout=1000
  */
 public class DefaultClientConfigImpl implements IClientConfig {
 
+    @Deprecated
     public static final Boolean DEFAULT_PRIORITIZE_VIP_ADDRESS_BASED_SERVERS = Boolean.TRUE;
 
+    @Deprecated
     public static final String DEFAULT_NFLOADBALANCER_PING_CLASSNAME = CommonClientConfigKey.NFLoadBalancerPingClassName.defaultValue();
 
+    @Deprecated
     public static final String DEFAULT_NFLOADBALANCER_RULE_CLASSNAME = CommonClientConfigKey.NFLoadBalancerRuleClassName.defaultValue();
 
+    @Deprecated
     public static final String DEFAULT_NFLOADBALANCER_CLASSNAME = CommonClientConfigKey.NFLoadBalancerClassName.defaultValue();
 
+    @Deprecated
     public static final boolean DEFAULT_USEIPADDRESS_FOR_SERVER = CommonClientConfigKey.UseIPAddrForServer.defaultValue();
 
+    @Deprecated
     public static final String DEFAULT_CLIENT_CLASSNAME = CommonClientConfigKey.ClientClassName.defaultValue();
 
+    @Deprecated
     public static final String DEFAULT_VIPADDRESS_RESOLVER_CLASSNAME = CommonClientConfigKey.VipAddressResolverClassName.defaultValue();
 
+    @Deprecated
     public static final String DEFAULT_PRIME_CONNECTIONS_URI = CommonClientConfigKey.PrimeConnectionsURI.defaultValue();
 
+    @Deprecated
     public static final int DEFAULT_MAX_TOTAL_TIME_TO_PRIME_CONNECTIONS = CommonClientConfigKey.MaxTotalTimeToPrimeConnections.defaultValue();
 
+    @Deprecated
     public static final int DEFAULT_MAX_RETRIES_PER_SERVER_PRIME_CONNECTION = CommonClientConfigKey.MaxRetriesPerServerPrimeConnection.defaultValue();
 
+    @Deprecated
     public static final Boolean DEFAULT_ENABLE_PRIME_CONNECTIONS = CommonClientConfigKey.EnablePrimeConnections.defaultValue();
 
+    @Deprecated
     public static final int DEFAULT_MAX_REQUESTS_ALLOWED_PER_WINDOW = Integer.MAX_VALUE;
 
+    @Deprecated
     public static final int DEFAULT_REQUEST_THROTTLING_WINDOW_IN_MILLIS = 60000;
 
+    @Deprecated
     public static final Boolean DEFAULT_ENABLE_REQUEST_THROTTLING = Boolean.FALSE;
 
+    @Deprecated
     public static final Boolean DEFAULT_ENABLE_GZIP_CONTENT_ENCODING_FILTER = CommonClientConfigKey.EnableGZIPContentEncodingFilter.defaultValue();
 
+    @Deprecated
     public static final Boolean DEFAULT_CONNECTION_POOL_CLEANER_TASK_ENABLED = CommonClientConfigKey.ConnectionPoolCleanerTaskEnabled.defaultValue();
 
+    @Deprecated
     public static final Boolean DEFAULT_FOLLOW_REDIRECTS = CommonClientConfigKey.FollowRedirects.defaultValue();
 
+    @Deprecated
     public static final float DEFAULT_PERCENTAGE_NIWS_EVENT_LOGGED = 0.0f;
 
+    @Deprecated
     public static final int DEFAULT_MAX_AUTO_RETRIES_NEXT_SERVER = CommonClientConfigKey.MaxAutoRetriesNextServer.defaultValue();
 
+    @Deprecated
     public static final int DEFAULT_MAX_AUTO_RETRIES = CommonClientConfigKey.MaxAutoRetries.defaultValue();
 
+    @Deprecated
     public static final int DEFAULT_BACKOFF_INTERVAL = CommonClientConfigKey.BackoffInterval.defaultValue();
 
+    @Deprecated
     public static final int DEFAULT_READ_TIMEOUT = CommonClientConfigKey.ReadTimeout.defaultValue();
 
+    @Deprecated
     public static final int DEFAULT_CONNECTION_MANAGER_TIMEOUT = CommonClientConfigKey.ConnectionManagerTimeout.defaultValue();
 
+    @Deprecated
     public static final int DEFAULT_CONNECT_TIMEOUT = CommonClientConfigKey.ConnectTimeout.defaultValue();
 
+    @Deprecated
     public static final Boolean DEFAULT_ENABLE_CONNECTION_POOL = CommonClientConfigKey.EnableConnectionPool.defaultValue();
 
     @Deprecated
@@ -141,20 +166,28 @@ public class DefaultClientConfigImpl implements IClientConfig {
     @Deprecated
     public static final int DEFAULT_MAX_TOTAL_HTTP_CONNECTIONS = CommonClientConfigKey.MaxTotalHttpConnections.defaultValue();
 
+    @Deprecated
     public static final int DEFAULT_MAX_CONNECTIONS_PER_HOST = CommonClientConfigKey.MaxConnectionsPerHost.defaultValue();
 
+    @Deprecated
     public static final int DEFAULT_MAX_TOTAL_CONNECTIONS = CommonClientConfigKey.MaxTotalConnections.defaultValue();
 
+    @Deprecated
     public static final float DEFAULT_MIN_PRIME_CONNECTIONS_RATIO = CommonClientConfigKey.MinPrimeConnectionsRatio.defaultValue();
 
+    @Deprecated
     public static final String DEFAULT_PRIME_CONNECTIONS_CLASS = CommonClientConfigKey.PrimeConnectionsClassName.defaultValue();
 
+    @Deprecated
     public static final String DEFAULT_SEVER_LIST_CLASS = CommonClientConfigKey.NIWSServerListClassName.defaultValue();
 
+    @Deprecated
     public static final String DEFAULT_SERVER_LIST_UPDATER_CLASS = CommonClientConfigKey.ServerListUpdaterClassName.defaultValue();
 
+    @Deprecated
     public static final int DEFAULT_CONNECTION_IDLE_TIMERTASK_REPEAT_IN_MSECS = 30000; // every half minute (30 secs)
 
+    @Deprecated
     public static final int DEFAULT_CONNECTIONIDLE_TIME_IN_MSECS = 30000; // all connections idle for 30 secs
 
     protected volatile Map<String, Object> properties = new ConcurrentHashMap<String, Object>();
@@ -172,13 +205,28 @@ public class DefaultClientConfigImpl implements IClientConfig {
      * Defaults for the parameters for the thread pool used by batchParallel
      * calls
      */
+    @Deprecated
     public static final int DEFAULT_POOL_MAX_THREADS = DEFAULT_MAX_TOTAL_HTTP_CONNECTIONS;
+
+    @Deprecated
     public static final int DEFAULT_POOL_MIN_THREADS = 1;
+
+    @Deprecated
     public static final long DEFAULT_POOL_KEEP_ALIVE_TIME = 15 * 60L;
+
+    @Deprecated
     public static final TimeUnit DEFAULT_POOL_KEEP_ALIVE_TIME_UNITS = TimeUnit.SECONDS;
+
+    @Deprecated
     public static final Boolean DEFAULT_ENABLE_ZONE_AFFINITY = CommonClientConfigKey.EnableZoneAffinity.defaultValue();
+
+    @Deprecated
     public static final Boolean DEFAULT_ENABLE_ZONE_EXCLUSIVITY = CommonClientConfigKey.EnableZoneExclusivity.defaultValue();
+
+    @Deprecated
     public static final int DEFAULT_PORT = CommonClientConfigKey.Port.defaultValue();
+
+    @Deprecated
     public static final Boolean DEFAULT_ENABLE_LOADBALANCER = CommonClientConfigKey.InitializeNFLoadBalancer.defaultValue();
 
     public static final String DEFAULT_PROPERTY_NAME_SPACE = CommonClientConfigKey.DEFAULT_NAME_SPACE;
@@ -674,10 +722,12 @@ public class DefaultClientConfigImpl implements IClientConfig {
      * @see com.netflix.niws.client.CliengConfig#setProperty(com.netflix.niws.client.ClientConfigKey, java.lang.Object)
      */
     @Override
+    @Deprecated
     public void setProperty(IClientConfigKey key, Object value){
         setPropertyInternal(key.key(), value);
     }
 
+    @Deprecated
     public DefaultClientConfigImpl withProperty(IClientConfigKey key, Object value) {
         setProperty(key, value);
         return this;
@@ -762,13 +812,10 @@ public class DefaultClientConfigImpl implements IClientConfig {
         }
     }
 
-    /* (non-Javadoc)
-     * @see com.netflix.niws.client.CliengConfig#containsProperty(com.netflix.niws.client.ClientConfigKey)
-     */
     @Override
+    @Deprecated
     public boolean containsProperty(IClientConfigKey key){
-        Object oo = getProperty(key);
-        return oo!=null? true: false;
+        return getProperty(key) != null;
     }
 
     @Override
@@ -792,6 +839,7 @@ public class DefaultClientConfigImpl implements IClientConfig {
         return sb.toString();
     }
 
+    @Deprecated
     public void setProperty(Properties props, String restClientName, String key, String value){
         props.setProperty( getInstancePropName(restClientName, key), value);
     }
@@ -806,7 +854,6 @@ public class DefaultClientConfigImpl implements IClientConfig {
         return restClientName + "." + getNameSpace() + "."
                 + key;
     }
-
 
     @Override
     public String getNameSpace() {
@@ -838,6 +885,7 @@ public class DefaultClientConfigImpl implements IClientConfig {
     }
 
     @Override
+    @Deprecated
     public int getPropertyAsInteger(IClientConfigKey key, int defaultValue) {
         Object rawValue = getProperty(key);
         if (rawValue != null) {
@@ -852,6 +900,7 @@ public class DefaultClientConfigImpl implements IClientConfig {
     }
 
     @Override
+    @Deprecated
     public String getPropertyAsString(IClientConfigKey key, String defaultValue) {
         Object rawValue = getProperty(key);
         if (rawValue != null) {
@@ -861,6 +910,7 @@ public class DefaultClientConfigImpl implements IClientConfig {
     }
 
     @Override
+    @Deprecated
     public boolean getPropertyAsBoolean(IClientConfigKey key,
                                         boolean defaultValue) {
         Object rawValue = getProperty(key);

--- a/ribbon-core/src/main/java/com/netflix/client/RequestSpecificRetryHandler.java
+++ b/ribbon-core/src/main/java/com/netflix/client/RequestSpecificRetryHandler.java
@@ -1,20 +1,18 @@
 package com.netflix.client;
 
-import java.net.SocketException;
-import java.util.List;
-
-import javax.annotation.Nullable;
-
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.netflix.client.config.CommonClientConfigKey;
 import com.netflix.client.config.IClientConfig;
 
+import javax.annotation.Nullable;
+import java.net.SocketException;
+import java.util.List;
+import java.util.Optional;
+
 /**
  * Implementation of RetryHandler created for each request which allows for request
  * specific override
- * @author elandau
- *
  */
 public class RequestSpecificRetryHandler implements RetryHandler {
 
@@ -37,12 +35,12 @@ public class RequestSpecificRetryHandler implements RetryHandler {
         this.okToRetryOnAllErrors = okToRetryOnAllErrors;
         this.fallback = baseRetryHandler;
         if (requestConfig != null) {
-            if (requestConfig.containsProperty(CommonClientConfigKey.MaxAutoRetries)) {
-                retrySameServer = requestConfig.get(CommonClientConfigKey.MaxAutoRetries); 
-            }
-            if (requestConfig.containsProperty(CommonClientConfigKey.MaxAutoRetriesNextServer)) {
-                retryNextServer = requestConfig.get(CommonClientConfigKey.MaxAutoRetriesNextServer); 
-            } 
+            Optional.ofNullable(requestConfig.get(CommonClientConfigKey.MaxAutoRetries)).ifPresent(
+                    value -> retrySameServer = value
+            );
+            Optional.ofNullable(requestConfig.get(CommonClientConfigKey.MaxAutoRetriesNextServer)).ifPresent(
+                    value -> retryNextServer = value
+            );
         }
     }
     

--- a/ribbon-core/src/main/java/com/netflix/client/config/IClientConfig.java
+++ b/ribbon-core/src/main/java/com/netflix/client/config/IClientConfig.java
@@ -65,17 +65,21 @@ public interface IClientConfig {
     @Deprecated
 	Object getProperty(IClientConfigKey key, Object defaultVal);
 
+    @Deprecated
 	boolean containsProperty(IClientConfigKey key);
 	
 	/**
 	 * Returns the applicable virtual addresses ("vip") used by this client configuration.
 	 */
 	String resolveDeploymentContextbasedVipAddresses();
-	
+
+    @Deprecated
 	int getPropertyAsInteger(IClientConfigKey key, int defaultValue);
 
+    @Deprecated
     String getPropertyAsString(IClientConfigKey key, String defaultValue);
-    
+
+    @Deprecated
     boolean getPropertyAsBoolean(IClientConfigKey key, boolean defaultValue);
     
     /**
@@ -131,6 +135,7 @@ public interface IClientConfig {
      */
     <T> IClientConfig set(IClientConfigKey<T> key, T value);
 
+    @Deprecated
     class Builder {
         
         private IClientConfig config;

--- a/ribbon-core/src/test/java/com/netflix/client/config/ClientConfigTest.java
+++ b/ribbon-core/src/test/java/com/netflix/client/config/ClientConfigTest.java
@@ -83,23 +83,23 @@ public class ClientConfigTest {
         ConfigurationManager.getConfigInstance().setProperty("testRestClient.ribbon.customProperty", "abc");
         
         clientConfig.loadProperties(restClientName);
-        clientConfig.setProperty(CommonClientConfigKey.ConnectTimeout, "1000");
-        override.setProperty(CommonClientConfigKey.Port, "8000");
-        override.setProperty(CommonClientConfigKey.ConnectTimeout, "5000");
+        clientConfig.set(CommonClientConfigKey.ConnectTimeout, 1000);
+        override.set(CommonClientConfigKey.Port, 8000);
+        override.set(CommonClientConfigKey.ConnectTimeout, 5000);
         clientConfig.applyOverride(override);
         
-        Assert.assertEquals("movieservice", clientConfig.getProperty(CommonClientConfigKey.AppName));
-        Assert.assertEquals("false", clientConfig.getProperty(CommonClientConfigKey.EnableZoneAffinity));        
+        Assert.assertEquals("movieservice", clientConfig.get(CommonClientConfigKey.AppName));
+        Assert.assertEquals(false, clientConfig.get(CommonClientConfigKey.EnableZoneAffinity));
         Assert.assertEquals("movieservice-xbox-test,movieservice--test", clientConfig.resolveDeploymentContextbasedVipAddresses());
-        Assert.assertEquals("5000", clientConfig.getProperty(CommonClientConfigKey.ConnectTimeout));
+        Assert.assertEquals(5000, clientConfig.get(CommonClientConfigKey.ConnectTimeout).longValue());
 
-        Assert.assertEquals("8000", clientConfig.getProperty(CommonClientConfigKey.Port));
+        Assert.assertEquals(8000, clientConfig.get(CommonClientConfigKey.Port).longValue());
         assertEquals("abc", clientConfig.getProperties().get("customProperty"));
         System.out.println("AutoVipAddress:" + clientConfig.resolveDeploymentContextbasedVipAddresses());
         
         ConfigurationManager.getConfigInstance().setProperty("testRestClient.ribbon.EnableZoneAffinity", "true");
         ConfigurationManager.getConfigInstance().setProperty("testRestClient.ribbon.customProperty", "xyz");
-        assertEquals("true", clientConfig.getProperty(CommonClientConfigKey.EnableZoneAffinity));
+        assertEquals(true, clientConfig.get(CommonClientConfigKey.EnableZoneAffinity));
         assertEquals("xyz", clientConfig.getProperties().get("customProperty"));        
     }
     
@@ -120,14 +120,14 @@ public class ClientConfigTest {
         
         clientConfig.loadProperties(restClientName);
         
-        Assert.assertEquals("movieservice", clientConfig.getProperty(CommonClientConfigKey.AppName));
-        Assert.assertEquals("true", clientConfig.getProperty(CommonClientConfigKey.EnableZoneAffinity));
+        Assert.assertEquals("movieservice", clientConfig.get(CommonClientConfigKey.AppName));
+        Assert.assertEquals(true, clientConfig.get(CommonClientConfigKey.EnableZoneAffinity));
         
         ConfigurationManager.getConfigInstance().setProperty("testRestClient2.ribbon.DeploymentContextBasedVipAddresses", "movieservice-xbox-test:7001");
-        assertEquals("movieservice-xbox-test:7001", clientConfig.getProperty(CommonClientConfigKey.DeploymentContextBasedVipAddresses));
+        assertEquals("movieservice-xbox-test:7001", clientConfig.get(CommonClientConfigKey.DeploymentContextBasedVipAddresses));
         
         ConfigurationManager.getConfigInstance().clearProperty("testRestClient2.ribbon.EnableZoneAffinity");
-        assertNull(clientConfig.getProperty(CommonClientConfigKey.EnableZoneAffinity));
+        assertNull(clientConfig.get(CommonClientConfigKey.EnableZoneAffinity));
     }
 
     @Test

--- a/ribbon-core/src/test/java/com/netflix/client/config/DefaultClientConfigImplTest.java
+++ b/ribbon-core/src/test/java/com/netflix/client/config/DefaultClientConfigImplTest.java
@@ -21,7 +21,6 @@ public class DefaultClientConfigImplTest {
         ConfigurationManager.getConfigInstance().setProperty("myclient.ribbon." + CommonClientConfigKey.ConnectTimeout, "1000");    
         DefaultClientConfigImpl config = new DefaultClientConfigImpl();
         config.loadProperties("myclient");
-        assertEquals("1000", config.getProperty(CommonClientConfigKey.ConnectTimeout));
         assertEquals(1000, config.get(CommonClientConfigKey.ConnectTimeout).intValue());
         config.set(CommonClientConfigKey.ConnectTimeout, 2000);
         // The archaius property should override code override

--- a/ribbon-eureka/src/main/java/com/netflix/niws/loadbalancer/DiscoveryEnabledNIWSServerList.java
+++ b/ribbon-eureka/src/main/java/com/netflix/niws/loadbalancer/DiscoveryEnabledNIWSServerList.java
@@ -19,6 +19,7 @@ package com.netflix.niws.loadbalancer;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.appinfo.InstanceInfo.InstanceStatus;
@@ -108,26 +109,27 @@ public class DiscoveryEnabledNIWSServerList extends AbstractServerList<Discovery
                 ConfigurationManager.getConfigInstance().getBoolean("DiscoveryEnabledNIWSServerList.failFastOnNullVip", true)) {
             throw new NullPointerException("VIP address for client " + clientName + " is null");
         }
-        isSecure = Boolean.parseBoolean(""+clientConfig.getProperty(CommonClientConfigKey.IsSecure, "false"));
-        prioritizeVipAddressBasedServers = Boolean.parseBoolean(""+clientConfig.getProperty(CommonClientConfigKey.PrioritizeVipAddressBasedServers, prioritizeVipAddressBasedServers));
+        isSecure = clientConfig.get(CommonClientConfigKey.IsSecure, false);
+        prioritizeVipAddressBasedServers = clientConfig.get(CommonClientConfigKey.PrioritizeVipAddressBasedServers, prioritizeVipAddressBasedServers);
         datacenter = ConfigurationManager.getDeploymentContext().getDeploymentDatacenter();
-        targetRegion = (String) clientConfig.getProperty(CommonClientConfigKey.TargetRegion);
+        targetRegion = clientConfig.get(CommonClientConfigKey.TargetRegion);
 
         shouldUseIpAddr = clientConfig.getOrDefault(CommonClientConfigKey.UseIPAddrForServer);
 
         // override client configuration and use client-defined port
-        if (clientConfig.getPropertyAsBoolean(CommonClientConfigKey.ForceClientPortConfiguration, false)){
+        if (clientConfig.get(CommonClientConfigKey.ForceClientPortConfiguration, false)){
             if (isSecure) {
-                if (clientConfig.containsProperty(CommonClientConfigKey.SecurePort)) {
-                    overridePort = clientConfig.getOrDefault(CommonClientConfigKey.SecurePort);
+                final Integer port = clientConfig.get(CommonClientConfigKey.SecurePort);
+                if (port != null) {
+                    overridePort = port;
                     shouldUseOverridePort = true;
-
                 } else {
                     logger.warn(clientName + " set to force client port but no secure port is set, so ignoring");
                 }
             } else {
-                if(clientConfig.containsProperty(CommonClientConfigKey.Port)){
-                    overridePort = clientConfig.getOrDefault(CommonClientConfigKey.Port);
+                final Integer port = clientConfig.get(CommonClientConfigKey.Port);
+                if (port != null) {
+                    overridePort = port;
                     shouldUseOverridePort = true;
                 } else{
                     logger.warn(clientName + " set to force client port but no port is set, so ignoring");

--- a/ribbon-eureka/src/test/java/com/netflix/loadbalancer/EurekaDynamicServerListLoadBalancerTest.java
+++ b/ribbon-eureka/src/test/java/com/netflix/loadbalancer/EurekaDynamicServerListLoadBalancerTest.java
@@ -66,8 +66,8 @@ public class EurekaDynamicServerListLoadBalancerTest {
         };
 
         config = DefaultClientConfigImpl.getClientConfigWithDefaultValues();
-        config.setProperty(CommonClientConfigKey.DeploymentContextBasedVipAddresses, vipAddress);
-        config.setProperty(CommonClientConfigKey.ServerListUpdaterClassName, EurekaNotificationServerListUpdater.class.getName());
+        config.set(CommonClientConfigKey.DeploymentContextBasedVipAddresses, vipAddress);
+        config.set(CommonClientConfigKey.ServerListUpdaterClassName, EurekaNotificationServerListUpdater.class.getName());
     }
 
 

--- a/ribbon-httpclient/src/main/java/com/netflix/http4/NFHttpClient.java
+++ b/ribbon-httpclient/src/main/java/com/netflix/http4/NFHttpClient.java
@@ -145,7 +145,7 @@ public class NFHttpClient extends DefaultHttpClient {
 		HttpProtocolParams.setContentCharset(params, "UTF-8");  
 		params.setParameter(ClientPNames.CONNECTION_MANAGER_FACTORY_CLASS_NAME, 
 				ThreadSafeClientConnManager.class.getName());
-		HttpClientParams.setRedirecting(params, config.getPropertyAsBoolean(CommonClientConfigKey.FollowRedirects, true));
+		HttpClientParams.setRedirecting(params, config.get(CommonClientConfigKey.FollowRedirects, true));
 		// set up default headers
 		List<Header> defaultHeaders = new ArrayList<Header>();
 		defaultHeaders.add(new BasicHeader("Netflix.NFHttpClient.Version", "1.0"));

--- a/ribbon-httpclient/src/test/java/com/netflix/niws/client/http/FollowRedirectTest.java
+++ b/ribbon-httpclient/src/test/java/com/netflix/niws/client/http/FollowRedirectTest.java
@@ -73,7 +73,7 @@ public class FollowRedirectTest {
     @Test
     public void testRedirectNotFollowed() throws Exception {
         IClientConfig config = DefaultClientConfigImpl.getClientConfigWithDefaultValues("myclient");
-        config.setProperty(CommonClientConfigKey.FollowRedirects, Boolean.FALSE);
+        config.set(CommonClientConfigKey.FollowRedirects, Boolean.FALSE);
         ClientFactory.registerClientFromProperties("myclient", config);
         RestClient client = (RestClient) ClientFactory.getNamedClient("myclient");
         HttpRequest request = HttpRequest.newBuilder().uri(new URI("http://localhost:" + redirectingServer.getPort())).build();

--- a/ribbon-loadbalancer/src/main/java/com/netflix/client/AbstractLoadBalancerAwareClient.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/client/AbstractLoadBalancerAwareClient.java
@@ -146,7 +146,7 @@ public abstract class AbstractLoadBalancerAwareClient<S extends ClientRequest, T
             boolean retryOkayOnOperation = okToRetryOnAllOperations;
             IClientConfig overriddenClientConfig = request.getOverrideConfig();
             if (overriddenClientConfig != null) {
-                retryOkayOnOperation = overriddenClientConfig.getPropertyAsBoolean(CommonClientConfigKey.RequestSpecificRetryOn, okToRetryOnAllOperations);
+                retryOkayOnOperation = overriddenClientConfig.get(CommonClientConfigKey.RequestSpecificRetryOn, okToRetryOnAllOperations);
             }
             return retryOkayOnOperation;
         }

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/AbstractServerList.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/AbstractServerList.java
@@ -38,13 +38,12 @@ public abstract class AbstractServerList<T extends Server> implements ServerList
      * The filter class name is determined by the value of {@link CommonClientConfigKey#NIWSServerListFilterClassName}
      * in the {@link IClientConfig}. The default implementation is {@link ZoneAffinityServerListFilter}.
      */
-    public AbstractServerListFilter<T> getFilterImpl(IClientConfig niwsClientConfig) throws ClientException{
+    public AbstractServerListFilter<T> getFilterImpl(IClientConfig niwsClientConfig) throws ClientException {
+        String niwsServerListFilterClassName = null;
         try {
-            String niwsServerListFilterClassName = niwsClientConfig
-                    .getProperty(
+            niwsServerListFilterClassName = niwsClientConfig.get(
                             CommonClientConfigKey.NIWSServerListFilterClassName,
-                            ZoneAffinityServerListFilter.class.getName())
-                    .toString();
+                            ZoneAffinityServerListFilter.class.getName());
 
             AbstractServerListFilter<T> abstractNIWSServerListFilter = 
                     (AbstractServerListFilter<T>) ClientFactory.instantiateInstanceWithClientConfig(niwsServerListFilterClassName, niwsClientConfig);
@@ -53,8 +52,7 @@ public abstract class AbstractServerList<T extends Server> implements ServerList
             throw new ClientException(
                     ClientException.ErrorType.CONFIGURATION,
                     "Unable to get an instance of CommonClientConfigKey.NIWSServerListFilterClassName. Configured class:"
-                            + niwsClientConfig
-                                    .getProperty(CommonClientConfigKey.NIWSServerListFilterClassName), e);
+                            + niwsServerListFilterClassName, e);
         }
     }
 }

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/BaseLoadBalancer.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/BaseLoadBalancer.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableList;
 import com.netflix.client.ClientFactory;
 import com.netflix.client.IClientConfigAware;
 import com.netflix.client.PrimeConnections;
-import com.netflix.client.config.ClientConfigFactory;
 import com.netflix.client.config.CommonClientConfigKey;
 import com.netflix.client.config.IClientConfig;
 import com.netflix.servo.annotations.DataSourceType;
@@ -169,16 +168,9 @@ public class BaseLoadBalancer extends AbstractLoadBalancer implements
     
     void initWithConfig(IClientConfig clientConfig, IRule rule, IPing ping, LoadBalancerStats stats) {
         this.config = clientConfig;
-        String clientName = clientConfig.getClientName();
-        this.name = clientName;
-        int pingIntervalTime = Integer.parseInt(""
-                + clientConfig.getProperty(
-                        CommonClientConfigKey.NFLoadBalancerPingInterval,
-                        Integer.parseInt("30")));
-        int maxTotalPingTime = Integer.parseInt(""
-                + clientConfig.getProperty(
-                        CommonClientConfigKey.NFLoadBalancerMaxTotalPingTime,
-                        Integer.parseInt("2")));
+        this.name = clientConfig.getClientName();
+        int pingIntervalTime = clientConfig.get(CommonClientConfigKey.NFLoadBalancerPingInterval, 30);
+        int maxTotalPingTime = clientConfig.get(CommonClientConfigKey.NFLoadBalancerMaxTotalPingTime, 2);
 
         setPingInterval(pingIntervalTime);
         setMaxTotalPingTime(maxTotalPingTime);

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/LoadBalancerContext.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/LoadBalancerContext.java
@@ -608,25 +608,10 @@ public class LoadBalancerContext implements IClientConfigAware {
         }
     }
 
-    /*
-    protected boolean isRetriable(T request) {
-        if (request.isRetriable()) {
-            return true;            
-        } else {
-            boolean retryOkayOnOperation = okToRetryOnAllOperations;
-            IClientConfig overriddenClientConfig = request.getOverrideConfig();
-            if (overriddenClientConfig != null) {
-                retryOkayOnOperation = overriddenClientConfig.getPropertyAsBoolean(CommonClientConfigKey.RequestSpecificRetryOn, okToRetryOnAllOperations);
-            }
-            return retryOkayOnOperation;
-        }
-    }
-     */
-
     protected int getRetriesNextServer(IClientConfig overriddenClientConfig) {
         int numRetries = maxAutoRetriesNextServer;
         if (overriddenClientConfig != null) {
-            numRetries = overriddenClientConfig.getPropertyAsInteger(CommonClientConfigKey.MaxAutoRetriesNextServer, maxAutoRetriesNextServer);
+            numRetries = overriddenClientConfig.get(CommonClientConfigKey.MaxAutoRetriesNextServer, maxAutoRetriesNextServer);
         }
         return numRetries;
     }
@@ -646,7 +631,7 @@ public class LoadBalancerContext implements IClientConfigAware {
         int numRetries =  maxAutoRetries;
         if (overriddenClientConfig!=null){
             try {
-                numRetries = overriddenClientConfig.getPropertyAsInteger(CommonClientConfigKey.MaxAutoRetries, maxAutoRetries);
+                numRetries = overriddenClientConfig.get(CommonClientConfigKey.MaxAutoRetries, maxAutoRetries);
             } catch (Exception e) {
                 logger.warn("Invalid maxRetries requested for RestClient:" + this.clientName);
             }

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/reactive/ExecutionContextListenerInvoker.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/reactive/ExecutionContextListenerInvoker.java
@@ -182,7 +182,7 @@ public class ExecutionContextListenerInvoker<I, O> {
                     key = old;
                 }
             }
-            return clientConfig.getPropertyAsBoolean(key, false);
+            return clientConfig.get(key, false);
         }
     }
 }

--- a/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/DynamicServerListLoadBalancerTest.java
+++ b/ribbon-loadbalancer/src/test/java/com/netflix/loadbalancer/DynamicServerListLoadBalancerTest.java
@@ -70,9 +70,9 @@ public class DynamicServerListLoadBalancerTest {
     @Test
     public void testDynamicServerListLoadBalancer() throws Exception {
         DefaultClientConfigImpl config = DefaultClientConfigImpl.getClientConfigWithDefaultValues();
-        config.setProperty(CommonClientConfigKey.NIWSServerListClassName, MyServerList.class.getName());
-        config.setProperty(CommonClientConfigKey.NFLoadBalancerClassName, DynamicServerListLoadBalancer.class.getName());
-        config.setProperty(CommonClientConfigKey.ServerListRefreshInterval, "50");
+        config.set(CommonClientConfigKey.NIWSServerListClassName, MyServerList.class.getName());
+        config.set(CommonClientConfigKey.NFLoadBalancerClassName, DynamicServerListLoadBalancer.class.getName());
+        config.set(CommonClientConfigKey.ServerListRefreshInterval, 50);
         DynamicServerListLoadBalancer<Server> lb = new DynamicServerListLoadBalancer<Server>(config);
         try {
             assertTrue(MyServerList.latch.await(2, TimeUnit.SECONDS));

--- a/ribbon-transport/src/main/java/com/netflix/ribbon/transport/netty/http/LoadBalancingHttpClient.java
+++ b/ribbon-transport/src/main/java/com/netflix/ribbon/transport/netty/http/LoadBalancingHttpClient.java
@@ -42,6 +42,7 @@ import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -184,7 +185,7 @@ public class LoadBalancingHttpClient<I, O> extends LoadBalancingRxClientWithPool
                 backoffStrategy = new Func1<Integer, Integer>() {
                     @Override
                     public Integer call(Integer backoffCount) {
-                        int interval = config.getPropertyAsInteger(IClientConfigKey.Keys.BackoffInterval, DefaultClientConfigImpl.DEFAULT_BACKOFF_INTERVAL);
+                        int interval = config.getOrDefault(IClientConfigKey.Keys.BackoffInterval);
                         if (backoffCount < 0) {
                             backoffCount = 0;
                         }
@@ -455,7 +456,7 @@ public class LoadBalancingHttpClient<I, O> extends LoadBalancingRxClientWithPool
         }
         int port = uri.getPort();
         if (port < 0) {
-            if (clientConfig.getPropertyAsBoolean(IClientConfigKey.Keys.IsSecure, false)) {
+            if (Optional.ofNullable(clientConfig.get(IClientConfigKey.Keys.IsSecure)).orElse(false)) {
                 port = 443;
             } else {
                 port = 80;


### PR DESCRIPTION
**What?**
- Deprecate all `DefaultClientConfigImpl` static defaults in favor of `CommonClientConfigKey` contain the default values
- Deprecate `IClientConfig#[setProperty, withProperty, containsProperty, setProperty, getPropertyAsInteger, getPropertyAsString, getPropertyAsBoolean]` all of which are replaced by `get` and `set`.
- Eliminate the awkward pattern of excessive conversion to and parsing of config string
- Leverage Java8 Optional to simplify config loading code

**Why?**
This is part of a long needed cleanup to simplify configuration loading