### PR TITLE
config: forEach methods to iterate config

### DIFF
--- a/ribbon-core/src/main/java/com/netflix/client/config/AbstractReloadableClientConfig.java
+++ b/ribbon-core/src/main/java/com/netflix/client/config/AbstractReloadableClientConfig.java
@@ -15,6 +15,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -113,6 +114,16 @@ public abstract class AbstractReloadableClientConfig implements IClientConfig {
 
         LOG.info(result.toString());
         return result;
+    }
+
+    @Override
+    public void forEachDefault(BiConsumer<IClientConfigKey<?>, Object> consumer) {
+        dynamicProperties.forEach((key, value) -> consumer.accept(key, defaultProperties.get(key.key())));
+    }
+
+    @Override
+    public void forEach(BiConsumer<IClientConfigKey<?>, Object> consumer) {
+        dynamicProperties.forEach((key, value) -> consumer.accept(key, value.get()));
     }
 
     /**

--- a/ribbon-core/src/main/java/com/netflix/client/config/IClientConfig.java
+++ b/ribbon-core/src/main/java/com/netflix/client/config/IClientConfig.java
@@ -18,6 +18,7 @@
 package com.netflix.client.config;
 
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 /**
  * Defines the client configuration used by various APIs to initialize clients or load balancers
@@ -46,6 +47,22 @@ public interface IClientConfig {
 	void loadDefaultValues();
 
 	Map<String, Object> getProperties();
+
+    /**
+     * Iterate all properties and report the default value only to the consumer
+     * @param consumer
+     */
+    default void forEachDefault(BiConsumer<IClientConfigKey<?>, Object> consumer) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Iterate all properties and report the final.  Can be null if a default value is not specified.
+     * @param consumer
+     */
+    default void forEach(BiConsumer<IClientConfigKey<?>, Object> consumer) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * @deprecated use {@link #set(IClientConfigKey, Object)} 


### PR DESCRIPTION
**What?**
`forEach` and `forEachDefault` methods to iterate config by `IClientConfigKey`.

**Why?**
This will make it easier to clone or copy config from one config to another