### PR TITLE
config: custom types with valueOf

### DIFF
--- a/ribbon-archaius/src/main/java/com/netflix/client/config/DefaultClientConfigImpl.java
+++ b/ribbon-archaius/src/main/java/com/netflix/client/config/DefaultClientConfigImpl.java
@@ -21,6 +21,8 @@ import com.netflix.client.VipAddressResolver;
 import com.netflix.config.ConfigurationManager;
 import org.apache.commons.configuration.event.ConfigurationEvent;
 import org.apache.commons.configuration.event.ConfigurationListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Optional;
@@ -73,6 +75,7 @@ myclient.foo.ReadTimeout=1000
  *
  */
 public class DefaultClientConfigImpl extends AbstractReloadableClientConfig {
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultClientConfigImpl.class);
 
     @Deprecated
     public static final Boolean DEFAULT_PRIORITIZE_VIP_ADDRESS_BASED_SERVERS = Boolean.TRUE;
@@ -616,11 +619,9 @@ public class DefaultClientConfigImpl extends AbstractReloadableClientConfig {
 
     @Override
     protected <T> Optional<T> loadProperty(String key, Class<T> type) {
-        if (String.class.equals(type)) {
-            return Optional.ofNullable(ConfigurationManager.getConfigInstance().getStringArray(key))
-                    .filter(ar -> ar.length > 0)
-                    .map(ar -> (T)Arrays.stream(ar).collect(Collectors.joining(",")));
-        } else if (Integer.class.equals(type)) {
+        LOG.debug("Loading property {}", key);
+
+        if (Integer.class.equals(type)) {
             return Optional.ofNullable((T) ConfigurationManager.getConfigInstance().getInteger(key, null));
         } else if (Boolean.class.equals(type)) {
             return Optional.ofNullable((T) ConfigurationManager.getConfigInstance().getBoolean(key, null));
@@ -632,9 +633,19 @@ public class DefaultClientConfigImpl extends AbstractReloadableClientConfig {
             return Optional.ofNullable((T) ConfigurationManager.getConfigInstance().getDouble(key, null));
         } else if (TimeUnit.class.equals(type)) {
             return Optional.ofNullable((T) TimeUnit.valueOf(ConfigurationManager.getConfigInstance().getString(key, null)));
+        } else {
+            return Optional.ofNullable(ConfigurationManager.getConfigInstance().getStringArray(key))
+                    .filter(ar -> ar.length > 0)
+                    .map(ar -> Arrays.stream(ar).collect(Collectors.joining(",")))
+                    .map(value -> {
+                        if (type.equals(String.class)) {
+                            return (T)value;
+                        } else {
+                            return resolveWithValueOf(type, value)
+                                .orElseThrow(() -> new IllegalArgumentException("Unable to convert value to desired type " + type));
+                        }
+                    });
         }
-
-        throw new IllegalArgumentException("Unable to convert value to desired type " + type);
     }
 
     public DefaultClientConfigImpl withProperty(IClientConfigKey key, Object value) {

--- a/ribbon-core/src/test/java/com/netflix/client/config/ClientConfigTest.java
+++ b/ribbon-core/src/test/java/com/netflix/client/config/ClientConfigTest.java
@@ -154,5 +154,42 @@ public class ClientConfigTest {
 
         Assert.assertEquals(200, prop.get().intValue());
     }
+
+    static class CustomValueOf {
+        private final String value;
+
+        public static CustomValueOf valueOf(String value) {
+            return new CustomValueOf(value);
+        }
+
+        public CustomValueOf(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+
+    public static IClientConfigKey<CustomValueOf> CUSTOM_KEY = new CommonClientConfigKey<CustomValueOf>("CustomValueOf", new CustomValueOf("default")) {};
+
+    @Test
+    public void testValueOfWithDefault() {
+        DefaultClientConfigImpl clientConfig = new DefaultClientConfigImpl();
+
+        CustomValueOf prop = clientConfig.getOrDefault(CUSTOM_KEY);
+        Assert.assertEquals("default", prop.getValue());
+    }
+
+    @Test
+    public void testValueOf() {
+        ConfigurationManager.getConfigInstance().setProperty("testValueOf.ribbon.CustomValueOf", "value");
+
+        DefaultClientConfigImpl clientConfig = new DefaultClientConfigImpl();
+        clientConfig.setClientName("testValueOf");
+
+        Property<CustomValueOf> prop = clientConfig.getDynamicProperty(CUSTOM_KEY);
+        Assert.assertEquals("value", prop.get().getValue());
+    }
 }
 


### PR DESCRIPTION
Supporting collections and custom types with dynamic config requires a great deal of custom code.  This can be greatly simplified by supporting deserialization using a valueOf static method of any type.