### PR TITLE
feature: Fix returning Property defaults

### DIFF
--- a/ribbon-core/src/main/java/com/netflix/client/config/FallbackProperty.java
+++ b/ribbon-core/src/main/java/com/netflix/client/config/FallbackProperty.java
@@ -1,5 +1,6 @@
 package com.netflix.client.config;
 
+import java.util.Optional;
 import java.util.function.Consumer;
 
 public final class FallbackProperty<T> implements Property<T> {
@@ -13,13 +14,22 @@ public final class FallbackProperty<T> implements Property<T> {
 
     @Override
     public void onChange(Consumer<T> consumer) {
-        primary.onChange(ignore -> consumer.accept(get()));
-        fallback.onChange(ignore -> consumer.accept(get()));
+        primary.onChange(ignore -> consumer.accept(getOrDefault()));
+        fallback.onChange(ignore -> consumer.accept(getOrDefault()));
     }
 
     @Override
-    public T get() {
-        return primary.getOptional().orElseGet(fallback::get);
+    public Optional<T> get() {
+        Optional<T> value = primary.get();
+        if (value.isPresent()) {
+            return value;
+        }
+        return fallback.get();
+    }
+
+    @Override
+    public T getOrDefault() {
+        return primary.get().orElseGet(fallback::getOrDefault);
     }
 
     @Override

--- a/ribbon-core/src/main/java/com/netflix/client/config/Property.java
+++ b/ribbon-core/src/main/java/com/netflix/client/config/Property.java
@@ -15,14 +15,14 @@ public interface Property<T> {
     void onChange(Consumer<T> consumer);
 
     /**
-     * @return Get the current value.  Can be null if no default value was defined
+     * @return Get the current value.  Can be null if not set
      */
-    T get();
+    Optional<T> get();
 
     /**
-     * @return Return the value only if not set.  Will return Optional.empty() instead of default value if not set
+     * @return Get the current value or the default value if not set
      */
-    default Optional<T> getOptional() { return Optional.ofNullable(get()); }
+    T getOrDefault();
 
     default Property<T> fallbackWith(Property<T> fallback) {
         return new FallbackProperty<>(this, fallback);
@@ -36,7 +36,12 @@ public interface Property<T> {
             }
 
             @Override
-            public T get() {
+            public Optional<T> get() {
+                return Optional.ofNullable(value);
+            }
+
+            @Override
+            public T getOrDefault() {
                 return value;
             }
 

--- a/ribbon-core/src/main/java/com/netflix/client/config/UnboxedIntProperty.java
+++ b/ribbon-core/src/main/java/com/netflix/client/config/UnboxedIntProperty.java
@@ -4,7 +4,7 @@ public class UnboxedIntProperty {
     private volatile int value;
 
     public UnboxedIntProperty(Property<Integer> delegate) {
-        this.value = delegate.get();
+        this.value = delegate.getOrDefault();
 
         delegate.onChange(newValue -> this.value = newValue);
     }

--- a/ribbon-core/src/test/java/com/netflix/client/config/ClientConfigTest.java
+++ b/ribbon-core/src/test/java/com/netflix/client/config/ClientConfigTest.java
@@ -130,7 +130,7 @@ public class ClientConfigTest {
         Property<Integer> prop = clientConfig.getGlobalProperty(INTEGER_PROPERTY.format(testName.getMethodName()))
                 .fallbackWith(clientConfig.getGlobalProperty(DEFAULT_INTEGER_PROPERTY));
 
-        Assert.assertEquals(30, prop.get().intValue());
+        Assert.assertEquals(30, prop.getOrDefault().intValue());
     }
 
     @Test
@@ -140,7 +140,7 @@ public class ClientConfigTest {
         Property<Integer> prop = clientConfig.getGlobalProperty(INTEGER_PROPERTY.format(testName.getMethodName()))
                 .fallbackWith(clientConfig.getGlobalProperty(DEFAULT_INTEGER_PROPERTY));
 
-        Assert.assertEquals(100, prop.get().intValue());
+        Assert.assertEquals(100, prop.getOrDefault().intValue());
     }
 
     @Test
@@ -152,7 +152,7 @@ public class ClientConfigTest {
         Property<Integer> prop = clientConfig.getGlobalProperty(INTEGER_PROPERTY.format(testName.getMethodName()))
                 .fallbackWith(clientConfig.getGlobalProperty(DEFAULT_INTEGER_PROPERTY));
 
-        Assert.assertEquals(200, prop.get().intValue());
+        Assert.assertEquals(200, prop.getOrDefault().intValue());
     }
 
     static class CustomValueOf {
@@ -189,7 +189,7 @@ public class ClientConfigTest {
         clientConfig.setClientName("testValueOf");
 
         Property<CustomValueOf> prop = clientConfig.getDynamicProperty(CUSTOM_KEY);
-        Assert.assertEquals("value", prop.get().getValue());
+        Assert.assertEquals("value", prop.getOrDefault().getValue());
     }
 }
 

--- a/ribbon-httpclient/src/main/java/com/netflix/http4/ConnectionPoolCleaner.java
+++ b/ribbon-httpclient/src/main/java/com/netflix/http4/ConnectionPoolCleaner.java
@@ -110,7 +110,7 @@ public class ConnectionPoolCleaner {
     
     void cleanupConnections(){
         connMgr.closeExpiredConnections();
-        connMgr.closeIdleConnections(connIdleEvictTimeMilliSeconds.get(), TimeUnit.MILLISECONDS);       
+        connMgr.closeIdleConnections(connIdleEvictTimeMilliSeconds.getOrDefault(), TimeUnit.MILLISECONDS);
     }
     
     public void shutdown() {

--- a/ribbon-httpclient/src/main/java/com/netflix/http4/NFHttpClient.java
+++ b/ribbon-httpclient/src/main/java/com/netflix/http4/NFHttpClient.java
@@ -158,8 +158,8 @@ public class NFHttpClient extends DefaultHttpClient {
 
 		this.sleepTimeFactorMsProperty = config.getGlobalProperty(SLEEP_TIME_FACTOR_MS.format(name));
 		setHttpRequestRetryHandler(
-				new NFHttpMethodRetryHandler(this.name, this.retriesProperty.get(), false,
-						this.sleepTimeFactorMsProperty.get()));
+				new NFHttpMethodRetryHandler(this.name, this.retriesProperty.getOrDefault(), false,
+						this.sleepTimeFactorMsProperty.getOrDefault()));
 	    tracer = Monitors.newTimer(EXECUTE_TRACER + "-" + name, TimeUnit.MILLISECONDS);
 	    if (registerMonitor) {
             Monitors.registerObject(name, this);
@@ -233,7 +233,7 @@ public class NFHttpClient extends DefaultHttpClient {
 
 	@Monitor(name = "HttpClient-NumRetries", type = DataSourceType.INFORMATIONAL)
 	public int getNumRetries() {
-		return this.retriesProperty.get();
+		return this.retriesProperty.getOrDefault();
 	}
 
 	public void setConnIdleEvictTimeMilliSeconds(Property<Integer> connIdleEvictTimeMilliSeconds) {
@@ -242,7 +242,7 @@ public class NFHttpClient extends DefaultHttpClient {
 
 	@Monitor(name = "HttpClient-SleepTimeFactorMs", type = DataSourceType.INFORMATIONAL)
 	public int getSleepTimeFactorMs() {
-		return this.sleepTimeFactorMsProperty.get();
+		return this.sleepTimeFactorMsProperty.getOrDefault();
 	}
 
 	// copied from httpclient source code

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/AvailabilityPredicate.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/AvailabilityPredicate.java
@@ -70,9 +70,9 @@ public class AvailabilityPredicate extends  AbstractServerPredicate {
     }
 
     private int getActiveConnectionsLimit() {
-        Integer limit = activeConnectionsLimit.get();
+        Integer limit = activeConnectionsLimit.getOrDefault();
         if (limit == -1) {
-            limit = defaultActiveConnectionsLimit.get();
+            limit = defaultActiveConnectionsLimit.getOrDefault();
             if (limit == -1) {
                 limit = Integer.MAX_VALUE;
             }
@@ -90,7 +90,7 @@ public class AvailabilityPredicate extends  AbstractServerPredicate {
     }
     
     private boolean shouldSkipServer(ServerStats stats) {
-        if ((circuitBreakerFiltering.get() && stats.isCircuitBreakerTripped())
+        if ((circuitBreakerFiltering.getOrDefault() && stats.isCircuitBreakerTripped())
                 || stats.getActiveRequestsCount() >= getActiveConnectionsLimit()) {
             return true;
         }

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ServerListSubsetFilter.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ServerListSubsetFilter.java
@@ -111,17 +111,17 @@ public class ServerListSubsetFilter<T extends Server> extends ZoneAffinityServer
             } else {
                 ServerStats stats = lbStats.getSingleServerStat(server);
                 // remove the servers that do not meet health criteria
-                if (stats.getActiveRequestsCount() > eliminationConnectionCountThreshold.get()
-                        || stats.getFailureCount() > eliminationFailureCountThreshold.get()) {
+                if (stats.getActiveRequestsCount() > eliminationConnectionCountThreshold.getOrDefault()
+                        || stats.getFailureCount() > eliminationFailureCountThreshold.getOrDefault()) {
                     newSubSet.remove(server);
                     // also remove from the general pool to avoid selecting them again
                     candidates.remove(server);
                 }
             }
         }
-        int targetedListSize = sizeProp.get();
+        int targetedListSize = sizeProp.getOrDefault();
         int numEliminated = currentSubset.size() - newSubSet.size();
-        int minElimination = (int) (targetedListSize * eliminationPercent.get());
+        int minElimination = (int) (targetedListSize * eliminationPercent.getOrDefault());
         int numToForceEliminate = 0;
         if (targetedListSize < newSubSet.size()) {
             // size is shrinking

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ZoneAffinityServerListFilter.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ZoneAffinityServerListFilter.java
@@ -79,7 +79,7 @@ public class ZoneAffinityServerListFilter<T extends Server> extends
     public void initWithNiwsConfig(IClientConfig niwsClientConfig) {
         zoneAffinity = niwsClientConfig.getOrDefault(CommonClientConfigKey.EnableZoneAffinity);
         zoneExclusive = niwsClientConfig.getOrDefault(CommonClientConfigKey.EnableZoneExclusivity);
-        zone = niwsClientConfig.getGlobalProperty(ZONE).get();
+        zone = niwsClientConfig.getGlobalProperty(ZONE).getOrDefault();
         zoneAffinityPredicate = new ZoneAffinityPredicate(zone);
 
         activeReqeustsPerServerThreshold = niwsClientConfig.getDynamicProperty(MAX_LOAD_PER_SERVER);
@@ -107,9 +107,9 @@ public class ZoneAffinityServerListFilter<T extends Server> extends
             double loadPerServer = snapshot.getLoadPerServer();
             int instanceCount = snapshot.getInstanceCount();            
             int circuitBreakerTrippedCount = snapshot.getCircuitTrippedCount();
-            if (((double) circuitBreakerTrippedCount) / instanceCount >= blackOutServerPercentageThreshold.get() 
-                    || loadPerServer >= activeReqeustsPerServerThreshold.get()
-                    || (instanceCount - circuitBreakerTrippedCount) < availableServersThreshold.get()) {
+            if (((double) circuitBreakerTrippedCount) / instanceCount >= blackOutServerPercentageThreshold.getOrDefault()
+                    || loadPerServer >= activeReqeustsPerServerThreshold.getOrDefault()
+                    || (instanceCount - circuitBreakerTrippedCount) < availableServersThreshold.getOrDefault()) {
                 logger.debug("zoneAffinity is overriden. blackOutServerPercentage: {}, activeReqeustsPerServer: {}, availableServers: {}", 
                         new Object[] {(double) circuitBreakerTrippedCount / instanceCount,  loadPerServer, instanceCount - circuitBreakerTrippedCount});
                 return false;

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ZoneAvoidancePredicate.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ZoneAvoidancePredicate.java
@@ -78,7 +78,7 @@ public class ZoneAvoidancePredicate extends AbstractServerPredicate {
 
     @Override
     public boolean apply(@Nullable PredicateKey input) {
-        if (!enabled.get()) {
+        if (!enabled.getOrDefault()) {
             return true;
         }
         String serverZone = input.getServer().getZone();
@@ -102,7 +102,7 @@ public class ZoneAvoidancePredicate extends AbstractServerPredicate {
             return true;
         }
         logger.debug("Zone snapshots: {}", zoneSnapshot);
-        Set<String> availableZones = ZoneAvoidanceRule.getAvailableZones(zoneSnapshot, triggeringLoad.get(), triggeringBlackoutPercentage.get());
+        Set<String> availableZones = ZoneAvoidanceRule.getAvailableZones(zoneSnapshot, triggeringLoad.getOrDefault(), triggeringBlackoutPercentage.getOrDefault());
         logger.debug("Available zones: {}", availableZones);
         if (availableZones != null) {
             return availableZones.contains(input.getServer().getZone());

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ZoneAwareLoadBalancer.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/ZoneAwareLoadBalancer.java
@@ -139,7 +139,7 @@ public class ZoneAwareLoadBalancer<T extends Server> extends DynamicServerListLo
         
     @Override
     public Server chooseServer(Object key) {
-        if (!enabled.get() || getLoadBalancerStats().getAvailableZones().size() <= 1) {
+        if (!enabled.getOrDefault() || getLoadBalancerStats().getAvailableZones().size() <= 1) {
             logger.debug("Zone aware logic disabled or there is only one zone");
             return super.chooseServer(key);
         }
@@ -148,7 +148,7 @@ public class ZoneAwareLoadBalancer<T extends Server> extends DynamicServerListLo
             LoadBalancerStats lbStats = getLoadBalancerStats();
             Map<String, ZoneSnapshot> zoneSnapshot = ZoneAvoidanceRule.createSnapshot(lbStats);
             logger.debug("Zone snapshots: {}", zoneSnapshot);
-            Set<String> availableZones = ZoneAvoidanceRule.getAvailableZones(zoneSnapshot, triggeringLoad.get(), triggeringBlackoutPercentage.get());
+            Set<String> availableZones = ZoneAvoidanceRule.getAvailableZones(zoneSnapshot, triggeringLoad.getOrDefault(), triggeringBlackoutPercentage.getOrDefault());
             logger.debug("Available zones: {}", availableZones);
             if (availableZones != null &&  availableZones.size() < zoneSnapshot.keySet().size()) {
                 String zone = ZoneAvoidanceRule.randomChooseZone(zoneSnapshot, availableZones);


### PR DESCRIPTION
The current mechanism for returning property default values is a bit awkward because of how property overrides are applied.  This change addresses that by adding an explicit `getOrDefault` api.