### PR TITLE
fix:support for setting SNI in zuul

### DIFF
--- a/ribbon-core/src/main/java/com/netflix/client/config/CommonClientConfigKey.java
+++ b/ribbon-core/src/main/java/com/netflix/client/config/CommonClientConfigKey.java
@@ -196,6 +196,8 @@ public abstract class CommonClientConfigKey<T> implements IClientConfigKey<T> {
     
     public static final IClientConfigKey<String> ListOfServers = new CommonClientConfigKey<String>("listOfServers", "") {};
 
+    public static final IClientConfigKey<String> SNI = new CommonClientConfigKey<String>("SNI", "") {};
+
     private static final Set<IClientConfigKey> keys = new HashSet<IClientConfigKey>();
         
     static {


### PR DESCRIPTION
Introduce property `<ribbon_client>.ribbon.SNI`

Needed for [Supporting Origins that need SNI](https://github.com/Netflix/zuul/issues/735)