### PR TITLE
Upgrading Travis CI to OpenJDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 sudo: false
 install: "./installViaTravis.sh"
 script: "./buildViaTravis.sh"


### PR DESCRIPTION
Oracle JDK 8 has been failing to build ribbon PRs for several
months due to the license agreement.  Netflix moved to OpenJDK
over one year ago.  Making this change to unblock PRs.