### PR TITLE
Add possibility to get ILoadBalancer by name and instance of IClientConfig

### DIFF
--- a/ribbon-loadbalancer/src/main/java/com/netflix/client/ClientFactory.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/client/ClientFactory.java
@@ -170,6 +170,24 @@ public class ClientFactory {
     }
 
     /**
+     * Get the load balancer associated with the name, or create one with the given clientConfig if does not exist
+     *
+     * @throws RuntimeException if any error occurs
+     * @see #registerNamedLoadBalancerFromclientConfig(String, IClientConfig)
+     */
+    public static synchronized ILoadBalancer getNamedLoadBalancer(String name, IClientConfig clientConfig) {
+        ILoadBalancer lb = namedLBMap.get(name);
+        if (lb == null) {
+            try {
+                lb = registerNamedLoadBalancerFromclientConfig(name, clientConfig);
+            } catch (ClientException e) {
+                throw new RuntimeException("Unable to create load balancer", e);
+            }
+        }
+        return lb;
+    }
+
+    /**
      * Create and register a load balancer with the name and given the class of configClass.
      *
      * @throws ClientException if load balancer with the same name already exists or any error occurs


### PR DESCRIPTION
Hi everybody!
I'd like to get ILoadBalancer by providing the name and IClientConfig instance. Currently we only have a way with Class<? extends IClientConfig> and in this case we will create an instance via newInstance() method.
But I need to provide the clientconfig instance created by myself, because it could be created with some additional parameters, could be configured in a special way (especially when i have to provide some parameters dynamically). In other words I need to provide the prepared IClientConfig instance instead of creation a new one. 
Also I want to return an existed loadbalancer (if it exists), that's why I can't use registerNamedLoadBalancerFromclientConfig method because it throws an exception if the balancer exists.
Currently I use reflection to get an access to namedLBMap to get balancer by name and call registerNamedLoadBalancerFromclientConfig if it doesn't exist.  

I can provide more details if it is required. 
Looking forward to your answers! Thanks!


