### PR TITLE
Use up server count to decide what server to select in RandomRule

### DIFF
--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/RandomRule.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/RandomRule.java
@@ -48,6 +48,7 @@ public class RandomRule extends AbstractLoadBalancerRule {
             List<Server> upList = lb.getReachableServers();
             List<Server> allList = lb.getAllServers();
 
+            int upCount = upList.size();
             int serverCount = allList.size();
             if (serverCount == 0) {
                 /*
@@ -57,7 +58,7 @@ public class RandomRule extends AbstractLoadBalancerRule {
                 return null;
             }
 
-            int index = chooseRandomInt(serverCount);
+            int index = chooseRandomInt(upCount);
             server = upList.get(index);
 
             if (server == null) {


### PR DESCRIPTION
Or else this causes an index out of bounds error if upList.size() < allList.size()