### PR TITLE
preserve cache when update with empty server list

### DIFF
--- a/ribbon-core/src/main/java/com/netflix/client/config/CommonClientConfigKey.java
+++ b/ribbon-core/src/main/java/com/netflix/client/config/CommonClientConfigKey.java
@@ -196,6 +196,8 @@ public abstract class CommonClientConfigKey<T> implements IClientConfigKey<T> {
     
     public static final IClientConfigKey<String> ListOfServers = new CommonClientConfigKey<String>("listOfServers", "") {};
 
+    public static final IClientConfigKey<Boolean> PreserveCacheWhenUpdateWithEmptyServerList = new CommonClientConfigKey<Boolean>("PreserveCacheWhenUpdateWithEmptyServerList", false) {};
+
     private static final Set<IClientConfigKey> keys = new HashSet<IClientConfigKey>();
         
     static {

--- a/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/DynamicServerListLoadBalancer.java
+++ b/ribbon-loadbalancer/src/main/java/com/netflix/loadbalancer/DynamicServerListLoadBalancer.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.netflix.client.config.CommonClientConfigKey.PreserveCacheWhenUpdateWithEmptyServerList;
+
 /**
  * A LoadBalancer that has the capabilities to obtain the candidate list of
  * servers using a dynamic source. i.e. The list of servers can potentially be
@@ -245,6 +247,10 @@ public class DynamicServerListLoadBalancer<T extends Server> extends BaseLoadBal
                 LOGGER.debug("Filtered List of Servers for {} obtained from Discovery client: {}",
                         getIdentifier(), servers);
             }
+        }
+
+        if (getClientConfig().get(PreserveCacheWhenUpdateWithEmptyServerList) && servers.size() == 0) {
+            return;
         }
         updateAllServerList(servers);
     }


### PR DESCRIPTION
Eureka server has self-preservation mode to protect backend server list in case of network problem. In our production environment, we find that  mechanism is not always useful. We think client side "self-preservation" is another choice. 