### PR TITLE
#452: Upgrade servo to version 0.13.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 rx_java_version=1.0.9
 rx_netty_version=0.4.9
-servo_version=0.10.1
+servo_version=0.13.2
 hystrix_version=1.4.3
 guava_version=19.0
 archaius_version=0.7.6


### PR DESCRIPTION
As stated in issue #452 servo version 0.10.1 has several CVE issues reported, see output from dependencyCheck plugin below.
Upgrading to 0.13.2 removes these CVE warnings.

> servo-core-0.10.1.jar (pkg:maven/com.netflix.servo/servo-core@0.10.1, cpe:2.3:a:docker:docker:0.10.1:*:*:*:*:*:*:*, cpe:2.3:a:travis-ci:travis_ci:0.10.1:*:*:*:*:*:*:*) : CVE-2014-0047, CVE-2014-0048, CVE-2014-5277, CVE-2014-5278, CVE-2014-5282, CVE-2014-6407, CVE-2014-8178, CVE-2014-8179, CVE-2014-9356, CVE-2014-9358, CVE-2015-3627, CVE-2015-3630, CVE-2015-3631, CVE-2016-3697, CVE-2017-14992, CVE-2019-13139, CVE-2019-13509, CVE-2019-15752, CVE-2019-16884, CVE-2019-5736, CVE-2020-27534, CVE-2021-21284, CVE-2021-21285, CVE-2021-3162
> servo-internal-0.10.1.jar (pkg:maven/com.netflix.servo/servo-internal@0.10.1, cpe:2.3:a:docker:docker:0.10.1:*:*:*:*:*:*:*, cpe:2.3:a:travis-ci:travis_ci:0.10.1:*:*:*:*:*:*:*) : CVE-2014-0047, CVE-2014-0048, CVE-2014-5277, CVE-2014-5278, CVE-2014-5282, CVE-2014-6407, CVE-2014-8178, CVE-2014-8179, CVE-2014-9356, CVE-2014-9358, CVE-2015-3627, CVE-2015-3630, CVE-2015-3631, CVE-2016-3697, CVE-2017-14992, CVE-2019-13139, CVE-2019-13509, CVE-2019-15752, CVE-2019-16884, CVE-2019-5736, CVE-2020-27534, CVE-2021-21284, CVE-2021-21285, CVE-2021-3162